### PR TITLE
[Enhancement] Set STARROCKS_BATCH_SIZE_DEFAULT default value to 4096

### DIFF
--- a/src/main/java/com/starrocks/connector/spark/cfg/ConfigurationOptions.java
+++ b/src/main/java/com/starrocks/connector/spark/cfg/ConfigurationOptions.java
@@ -53,7 +53,7 @@ public interface ConfigurationOptions {
     int STARROCKS_TABLET_SIZE_MIN = 1;
 
     String STARROCKS_BATCH_SIZE = "starrocks.batch.size";
-    int STARROCKS_BATCH_SIZE_DEFAULT = 1024;
+    int STARROCKS_BATCH_SIZE_DEFAULT = 4096;
 
     String STARROCKS_EXEC_MEM_LIMIT = "starrocks.exec.mem.limit";
     long STARROCKS_EXEC_MEM_LIMIT_DEFAULT = 2147483648L;


### PR DESCRIPTION
Since StarRocks 2.2, the allowed minimum batch size is 4096, and when setting a batch size smaller than 4096, the StarRocks will reset it to 4096. To make the default value meaningful for all versions of StarRocks, we change the default value to 4096.