### PR TITLE
[Feature] Support to set the number of partitions for write

### DIFF
--- a/src/main/java/com/starrocks/connector/spark/sql/write/StarRocksWriteBuilder.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/write/StarRocksWriteBuilder.java
@@ -4,20 +4,29 @@ import com.starrocks.connector.spark.sql.conf.WriteStarRocksConfig;
 import com.starrocks.connector.spark.sql.schema.CsvRowStringConverter;
 import com.starrocks.connector.spark.sql.schema.JSONRowStringConverter;
 import com.starrocks.connector.spark.sql.schema.RowStringConverter;
+import org.apache.spark.sql.connector.distributions.Distribution;
+import org.apache.spark.sql.connector.distributions.Distributions;
+import org.apache.spark.sql.connector.expressions.Expression;
+import org.apache.spark.sql.connector.expressions.Expressions;
+import org.apache.spark.sql.connector.expressions.SortOrder;
 import org.apache.spark.sql.connector.write.BatchWrite;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.RequiresDistributionAndOrdering;
+import org.apache.spark.sql.connector.write.Write;
 import org.apache.spark.sql.connector.write.WriteBuilder;
 import org.apache.spark.sql.connector.write.streaming.StreamingWrite;
 
 public class StarRocksWriteBuilder implements WriteBuilder {
     private final LogicalWriteInfo info;
     private final WriteStarRocksConfig config;
-    private final RowStringConverter converter;
 
     public StarRocksWriteBuilder(LogicalWriteInfo info, WriteStarRocksConfig config) {
         this.info = info;
         this.config = config;
+    }
 
+    @Override
+    public Write build() {
         RowStringConverter converter;
         if ("csv".equalsIgnoreCase(config.getFormat())) {
             converter = new CsvRowStringConverter(info.schema(), config.getColumnSeparator());
@@ -26,16 +35,63 @@ public class StarRocksWriteBuilder implements WriteBuilder {
         } else {
             throw new RuntimeException("UnSupport format " + config.getFormat());
         }
-        this.converter = converter;
+        return new StarRocksWriteImpl(info, config, converter);
     }
 
-    @Override
-    public BatchWrite buildForBatch() {
-        return new StarRocksWrite(info, config, converter);
-    }
+    private static class StarRocksWriteImpl implements Write, RequiresDistributionAndOrdering {
 
-    @Override
-    public StreamingWrite buildForStreaming() {
-        return new StarRocksWrite(info, config, converter);
+        private final LogicalWriteInfo info;
+        private final WriteStarRocksConfig config;
+        private final RowStringConverter converter;
+
+        public StarRocksWriteImpl(LogicalWriteInfo info, WriteStarRocksConfig config, RowStringConverter converter) {
+            this.info = info;
+            this.config = config;
+            this.converter = converter;
+        }
+
+        @Override
+        public String description() {
+            return String.format("StarRocksWriteImpl[%s.%s]", config.getDatabase(), config.getTable());
+        }
+
+        @Override
+        public BatchWrite toBatch() {
+            return new StarRocksWrite(info, config, converter);
+        }
+
+        @Override
+        public StreamingWrite toStreaming() {
+            return new StarRocksWrite(info, config, converter);
+        }
+
+        @Override
+        public int requiredNumPartitions() {
+            return config.getNumPartitions();
+        }
+
+        @Override
+        public Distribution requiredDistribution() {
+            if (config.getNumPartitions() <= 0) {
+                return Distributions.unspecified();
+            }
+
+            String[] partitionColumns = config.getPartitionColumns();
+            if (partitionColumns == null) {
+                partitionColumns = info.schema().names();
+            }
+
+            Expression[] expressions = new Expression[partitionColumns.length];
+            for (int i = 0; i < partitionColumns.length; i++) {
+                expressions[i] = Expressions.column(partitionColumns[i]);
+            }
+
+            return Distributions.clustered(expressions);
+        }
+
+        @Override
+        public SortOrder[] requiredOrdering() {
+            return new SortOrder[0];
+        }
     }
 }

--- a/src/main/java/com/starrocks/connector/spark/sql/write/StarRocksWriteBuilder.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/write/StarRocksWriteBuilder.java
@@ -76,6 +76,7 @@ public class StarRocksWriteBuilder implements WriteBuilder {
                 return Distributions.unspecified();
             }
 
+            // TODO is it possible to implement a distribution without shuffle like DataSet#coalesce
             String[] partitionColumns = config.getPartitionColumns();
             if (partitionColumns == null) {
                 partitionColumns = info.schema().names();


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Support to set the number of partitions for write by implementing interface [`RequiresDistributionAndOrdering`](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RequiresDistributionAndOrdering.java) . The configurations are
* `starrocks.write.num.partitions`: the number of partitions used for write                                                                                                                             
* `starrocks.write.partition.columns`: the columns used for hash partition

The repartition is based on hash partition which will introduce shuffle cost. I have not found how to implement a repartition without shuffle like Spark [DataSet#coalesce](https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala#L3798) under DataSource V2 API. Improve it in the future if possible.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function