### PR TITLE
[Enhancement] Optimize the data type mappings between starrocks and spark

### DIFF
--- a/src/main/java/com/starrocks/connector/spark/cfg/Settings.java
+++ b/src/main/java/com/starrocks/connector/spark/cfg/Settings.java
@@ -19,6 +19,7 @@
 
 package com.starrocks.connector.spark.cfg;
 
+import com.google.common.collect.Maps;
 import com.starrocks.connector.spark.exception.IllegalArgumentException;
 import com.starrocks.connector.spark.util.ErrorMessages;
 import com.starrocks.connector.spark.util.IOUtils;
@@ -100,5 +101,9 @@ public abstract class Settings implements Serializable {
     public String save() throws IllegalArgumentException {
         Properties copy = asProperties();
         return IOUtils.propsToString(copy);
+    }
+
+    public Map<String, String> getPropertyMap() {
+        return Maps.fromProperties(asProperties());
     }
 }

--- a/src/main/java/com/starrocks/connector/spark/sql/conf/StarRocksConfigBase.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/conf/StarRocksConfigBase.java
@@ -49,7 +49,7 @@ public abstract class StarRocksConfigBase implements StarRocksConfig {
     static final String KEY_REQUEST_RETRIES = STARROCKS_REQUEST_RETRIES;
     static final String KEY_REQUEST_CONNECT_TIMEOUT = STARROCKS_REQUEST_CONNECT_TIMEOUT_MS;
     static final String KEY_REQUEST_SOCKET_TIMEOUT = STARROCKS_REQUEST_READ_TIMEOUT_MS;
-    static final String KEY_COLUMNS = PREFIX + "columns";
+    public static final String KEY_COLUMNS = PREFIX + "columns";
 
     protected final Map<String, String> originOptions;
 

--- a/src/main/java/com/starrocks/connector/spark/sql/connect/StarRocksConnector.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/connect/StarRocksConnector.java
@@ -10,12 +10,12 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 public class StarRocksConnector {
 
@@ -25,51 +25,41 @@ public class StarRocksConnector {
                 config.getFeJdbcUrl(),
                 config.getUsername(),
                 config.getPassword(),
-                "SELECT `COLUMN_NAME`, `COLUMN_KEY`, `DATA_TYPE`, `COLUMN_SIZE`, `DECIMAL_DIGITS` from `information_schema`.`COLUMNS` where `TABLE_SCHEMA`=? and `TABLE_NAME`=?;",
                 config.getDatabase(),
                 config.getTable()
         );
 
-        List<StarRocksField> pks = new LinkedList<>();
-
-        LinkedHashMap<String, StarRocksField> columns = new LinkedHashMap<>();
-
+        List<StarRocksField> pks = new ArrayList<>();
+        List<StarRocksField> columns = new ArrayList<>();
         for (Map<String, String> columnValue : columnValues) {
-            StarRocksField field = new StarRocksField();
-
-            field.setName(columnValue.get("COLUMN_NAME"));
-            field.setType(columnValue.get("DATA_TYPE"));
-            field.setSize(columnValue.get("COLUMN_SIZE"));
-            field.setSize(columnValue.get("DECIMAL_DIGITS"));
-
-            columns.put(field.getName(), field);
-
+            StarRocksField field = new StarRocksField(
+                    columnValue.get("COLUMN_NAME"),
+                    columnValue.get("DATA_TYPE"),
+                    Integer.parseInt(columnValue.get("ORDINAL_POSITION")),
+                    columnValue.get("COLUMN_SIZE"),
+                    columnValue.get("DECIMAL_DIGITS")
+            );
+            columns.add(field);
             if ("PRI".equals(columnValue.get("COLUMN_KEY"))) {
                 pks.add(field);
             }
         }
+        columns.sort(Comparator.comparingInt(StarRocksField::getOrdinalPosition));
 
-        StarRocksSchema schema = new StarRocksSchema();
-        schema.setFieldMap(columns);
-        schema.setPks(pks);
-
-        return schema;
+        return new StarRocksSchema(columns, pks);
     }
 
-    private static List<Map<String, String>> extractColumnValuesBySql(String url,
-                                                                      String username,
-                                                                      String password,
-                                                                      String sql,
-                                                                      Object... args) {
-        List<Map<String, String>> columnValues = new ArrayList<>();
+    private static final String TABLE_SCHEMA_QUERY =
+            "SELECT `COLUMN_NAME`, `ORDINAL_POSITION`, `COLUMN_KEY`, `DATA_TYPE`, `COLUMN_SIZE`, `DECIMAL_DIGITS` " +
+                    "FROM `information_schema`.`COLUMNS` WHERE `TABLE_SCHEMA`=? AND `TABLE_NAME`=?;";
 
-        try (Connection conn = DriverManager.getConnection(url, username, password);
-             PreparedStatement ps = conn.prepareStatement(sql)) {
-            if (Objects.nonNull(args) && args.length > 0) {
-                for (int i = 0; i < args.length; i++) {
-                    ps.setObject(i + 1, args[i]);
-                }
-            }
+    private static List<Map<String, String>> extractColumnValuesBySql(
+            String jdbcUrl, String username,  String password, String database, String table) {
+        List<Map<String, String>> columnValues = new ArrayList<>();
+        try (Connection conn = DriverManager.getConnection(jdbcUrl, username, password);
+             PreparedStatement ps = conn.prepareStatement(TABLE_SCHEMA_QUERY)) {
+            ps.setObject(1, database);
+            ps.setObject(2, table);
             ResultSet rs = ps.executeQuery();
             ResultSetMetaData metaData = rs.getMetaData();
             int columnCount = metaData.getColumnCount();
@@ -80,6 +70,7 @@ public class StarRocksConnector {
                 }
                 columnValues.add(row);
             }
+            rs.close();
             return columnValues;
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/main/java/com/starrocks/connector/spark/sql/schema/InferSchema.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/schema/InferSchema.java
@@ -13,11 +13,12 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public final class InferSchema {
 
-    public static StructType inferSchema(final CaseInsensitiveStringMap options) {
+    public static StructType inferSchema(final Map<String, String> options) {
         StarRocksConfig config = new SimpleStarRocksConfig(options);
         StarRocksSchema schema = StarRocksConnector.getSchema(config);
 

--- a/src/main/java/com/starrocks/connector/spark/sql/schema/InferSchema.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/schema/InferSchema.java
@@ -11,65 +11,28 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.stream.Collectors;
-
-import static com.starrocks.connector.spark.sql.conf.StarRocksConfig.PREFIX;
 
 public final class InferSchema {
 
-    static String INFER_PREFIX = PREFIX + "infer.";
-
-    interface InferConf {
-        String KEY_COLUMNS = INFER_PREFIX + "columns";
-        String KEY_COLUMN_PREFIX = INFER_PREFIX + "column.";
-        String KEY_COLUMN_TYPE_SUFFIX = ".type";
-        String KEY_COLUMN_PRECISION_SUFFIX = ".precision";
-        String KEY_COLUMN_SCALE_SUFFIX = ".scale";
-    }
-
-    public static List<StarRocksField> inferFields(Map<String, String> options) {
-        String inferColumns = options.get(InferConf.KEY_COLUMNS);
-        if (inferColumns == null) {
-            return Collections.emptyList();
-        }
-
-        String[] columns = inferColumns.split(",");
-        List<StarRocksField> fields = new ArrayList<>(columns.length);
-        for (String column : columns) {
-            StarRocksField field = new StarRocksField();
-            field.setName(column);
-            field.setType(options.get(InferConf.KEY_COLUMN_PREFIX + column + InferConf.KEY_COLUMN_TYPE_SUFFIX));
-            field.setSize(options.get(InferConf.KEY_COLUMN_PREFIX + column + InferConf.KEY_COLUMN_PRECISION_SUFFIX));
-            field.setScale(options.get(InferConf.KEY_COLUMN_PREFIX + column + InferConf.KEY_COLUMN_SCALE_SUFFIX));
-            fields.add(field);
-        }
-        return fields;
-    }
-
     public static StructType inferSchema(final CaseInsensitiveStringMap options) {
         StarRocksConfig config = new SimpleStarRocksConfig(options);
-        List<StarRocksField> inferFields = inferFields(options);
-        if (!inferFields.isEmpty()) {
-            return inferSchema(inferFields);
-        }
-
         StarRocksSchema schema = StarRocksConnector.getSchema(config);
 
-        if (config.getColumns() != null && config.getColumns().length > 0) {
-            return inferSchema(schema.sortAndListField(config.getColumns()));
+        String[] inputColumns = config.getColumns();
+        List<StarRocksField> starRocksFields;
+        if (inputColumns == null || inputColumns.length == 0) {
+            starRocksFields = schema.getColumns();
+        } else {
+            starRocksFields = new ArrayList<>();
+            for (String column : inputColumns) {
+                starRocksFields.add(schema.getField(column));
+            }
         }
 
-        return inferSchema(schema.getFieldMap().values());
-    }
-
-    static StructType inferSchema(Collection<StarRocksField> srFields) {
-
-        List<StructField> fields = srFields.stream()
+        List<StructField> fields = starRocksFields.stream()
                 .map(InferSchema::inferStructField)
                 .collect(Collectors.toList());
 
@@ -81,20 +44,22 @@ public final class InferSchema {
 
         return new StructField(field.getName(), dataType, true, Metadata.empty());
     }
-
     static DataType inferDataType(StarRocksField field) {
         String type = field.getType().toLowerCase(Locale.ROOT);
-
         switch (type) {
-            case "largeint":
-            case "bigint":
-                return DataTypes.LongType;
             case "tinyint":
+                // mysql does not have boolean type, and starrocks `information_schema`.`COLUMNS` will return
+                // a "tinyint" data type for both StarRocks BOOLEAN and TINYINT type, We distinguish them by
+                // column size, and the size of BOOLEAN is null
+                return field.getSize() == null ? DataTypes.BooleanType : DataTypes.ByteType;
             case "smallint":
+                return DataTypes.ShortType;
             case "int":
                 return DataTypes.IntegerType;
-            case "boolean":
-                return DataTypes.BooleanType;
+            case "bigint":
+                return DataTypes.LongType;
+            case "bigint unsigned":
+                return DataTypes.StringType;
             case "float":
                 return DataTypes.FloatType;
             case "double":
@@ -104,14 +69,14 @@ public final class InferSchema {
             case "char":
             case "varchar":
             case "json":
-            case "string":
                 return DataTypes.StringType;
             case "date":
                 return DataTypes.DateType;
             case "datetime":
                 return DataTypes.TimestampType;
             default:
-                return DataTypes.NullType;
+                throw new UnsupportedOperationException(String.format(
+                        "Unsupported starrocks type, column name: %s, data type: %s", field.getName(), field.getType()));
         }
     }
 }

--- a/src/main/java/com/starrocks/connector/spark/sql/schema/StarRocksField.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/schema/StarRocksField.java
@@ -2,23 +2,18 @@ package com.starrocks.connector.spark.sql.schema;
 
 public class StarRocksField {
 
-    public static final StarRocksField __OP = new StarRocksField("__op", "tinyint");
+    public static final StarRocksField __OP = new StarRocksField("__op", "tinyint", Integer.MAX_VALUE, null, null);
 
     private String name;
     private String type;
+    private int ordinalPosition;
     private String size;
     private String scale;
 
-    public StarRocksField() {
-    }
-
-    private StarRocksField(String name, String type) {
-        this(name, type, null, null);
-    }
-
-    public StarRocksField(String name, String type, String size, String scale) {
+    public StarRocksField(String name, String type, int ordinalPosition, String size, String scale) {
         this.name = name;
         this.type = type;
+        this.ordinalPosition = ordinalPosition;
         this.size = size;
         this.scale = scale;
     }
@@ -27,31 +22,19 @@ public class StarRocksField {
         return name;
     }
 
-    public void setName(String name) {
-        this.name = name;
-    }
-
     public String getType() {
         return type;
     }
 
-    public void setType(String type) {
-        this.type = type;
+    public int getOrdinalPosition() {
+        return ordinalPosition;
     }
 
     public String getSize() {
         return size;
     }
 
-    public void setSize(String size) {
-        this.size = size;
-    }
-
     public String getScale() {
         return scale;
-    }
-
-    public void setScale(String scale) {
-        this.scale = scale;
     }
 }

--- a/src/main/java/com/starrocks/connector/spark/sql/schema/StarRocksSchema.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/schema/StarRocksSchema.java
@@ -1,41 +1,32 @@
 package com.starrocks.connector.spark.sql.schema;
 
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class StarRocksSchema {
-    private LinkedHashMap<String, StarRocksField> fieldMap;
-    private List<StarRocksField> pks;
+    private final List<StarRocksField> columns;
+    private final List<StarRocksField> pks;
+    private final Map<String, StarRocksField> columnMap;
 
-    public LinkedHashMap<String, StarRocksField> getFieldMap() {
-        return fieldMap;
+    public StarRocksSchema(List<StarRocksField> columns, List<StarRocksField> pks) {
+        this.columns = columns;
+        this.pks = pks;
+        this.columnMap = new HashMap<>();
+        for (StarRocksField field : columns) {
+            columnMap.put(field.getName(), field);
+        }
     }
 
-    public void setFieldMap(LinkedHashMap<String, StarRocksField> fieldMap) {
-        this.fieldMap = fieldMap;
+    public List<StarRocksField> getColumns() {
+        return columns;
     }
 
     public List<StarRocksField> getPks() {
         return pks;
     }
 
-    public void setPks(List<StarRocksField> pks) {
-        this.pks = pks;
-    }
-
-    public List<StarRocksField> sortAndListField(String[] fieldNames) {
-        List<StarRocksField> fields = new LinkedList<>();
-        for (String fieldName : fieldNames) {
-            if (StarRocksField.__OP.getName().equalsIgnoreCase(fieldName)) {
-                fields.add(StarRocksField.__OP);
-                continue;
-            }
-            StarRocksField field = fieldMap.get(fieldName);
-            if (field != null) {
-                fields.add(field);
-            }
-        }
-        return fields;
+    public StarRocksField getField(String columnName) {
+        return columnMap.get(columnName);
     }
 }

--- a/src/main/scala/com/starrocks/connector/spark/sql/StarrocksRelation.scala
+++ b/src/main/scala/com/starrocks/connector/spark/sql/StarrocksRelation.scala
@@ -22,10 +22,9 @@ package com.starrocks.connector.spark.sql
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.math.min
-
 import com.starrocks.connector.spark.cfg.ConfigurationOptions._
 import com.starrocks.connector.spark.cfg.{ConfigurationOptions, SparkSettings}
-
+import com.starrocks.connector.spark.sql.schema.InferSchema
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.jdbc.JdbcDialects
 import org.apache.spark.sql.sources._
@@ -47,7 +46,7 @@ private[sql] class StarrocksRelation(
     min(cfg.getProperty(STARROCKS_FILTER_QUERY_IN_MAX_COUNT, "100").toInt,
       STARROCKS_FILTER_QUERY_IN_VALUE_UPPER_LIMIT)
 
-  private lazy val lazySchema = SchemaUtils.discoverSchema(cfg)
+  private lazy val lazySchema = InferSchema.inferSchema(cfg.getPropertyMap)
 
   private lazy val dialect = JdbcDialects.get("")
 

--- a/src/test/java/com/starrocks/connector/spark/serialization/TestRowBatch.java
+++ b/src/test/java/com/starrocks/connector/spark/serialization/TestRowBatch.java
@@ -19,15 +19,12 @@
 
 package com.starrocks.connector.spark.serialization;
 
+import com.google.common.collect.ImmutableList;
 import com.starrocks.connector.spark.rest.RestService;
 import com.starrocks.connector.spark.rest.models.Schema;
 import com.starrocks.thrift.TScanBatchResult;
 import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
-
-import static org.hamcrest.core.StringStartsWith.startsWith;
-
-import com.google.common.collect.ImmutableList;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
@@ -57,9 +54,13 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
+
+import static org.hamcrest.core.StringStartsWith.startsWith;
 
 public class TestRowBatch {
     private static Logger logger = LoggerFactory.getLogger(TestRowBatch.class);
@@ -256,8 +257,8 @@ public class TestRowBatch {
                 1L,
                 (float) 1.1,
                 (double) 1.1,
-                "2008-08-08",
-                "2008-08-08 00:00:00",
+                Date.valueOf("2008-08-08"),
+                Timestamp.valueOf("2008-08-08 00:00:00"),
                 Decimal.apply(1234L, 4, 2),
                 "char1"
         );
@@ -270,8 +271,8 @@ public class TestRowBatch {
                 2L,
                 (float) 2.2,
                 (double) 2.2,
-                "1900-08-08",
-                "1900-08-08 00:00:00",
+                Date.valueOf("1900-08-08"),
+                Timestamp.valueOf("1900-08-08 00:00:00"),
                 Decimal.apply(8888L, 4, 2),
                 "char2"
         );
@@ -284,8 +285,8 @@ public class TestRowBatch {
                 3L,
                 (float) 3.3,
                 (double) 3.3,
-                "2100-08-08",
-                "2100-08-08 00:00:00",
+                Date.valueOf("2100-08-08"),
+                Timestamp.valueOf("2100-08-08 00:00:00"),
                 Decimal.apply(10L, 2, 0),
                 "char3"
         );

--- a/src/test/java/com/starrocks/connector/spark/sql/ReadITTest.java
+++ b/src/test/java/com/starrocks/connector/spark/sql/ReadITTest.java
@@ -43,6 +43,7 @@ public class ReadITTest {
 //    );
 
     private static final String FE_HTTP = "127.0.0.1:11901";
+    private static final String FE_JDBC = "jdbc:mysql://127.0.0.1:11903";
     private static final String TABLE_ID = "starrocks.score_board";
     private static final String USER = "root";
     private static final String PASSWORD = "";
@@ -58,6 +59,7 @@ public class ReadITTest {
         Dataset<Row> df = spark.read().format("starrocks")
                 .option("starrocks.table.identifier", TABLE_ID)
                 .option("starrocks.fenodes", FE_HTTP)
+                .option("starrocks.fe.jdbc.url", FE_JDBC)
                 .option("user", USER)
                 .option("password", PASSWORD)
                 .load();
@@ -80,9 +82,10 @@ public class ReadITTest {
                 "OPTIONS(\n" +
                 "  \"starrocks.table.identifier\"=\"%s\",\n" +
                 "  \"starrocks.fenodes\"=\"%s\",\n" +
+                "  \"starrocks.fe.jdbc.url\"=\"%s\",\n" +
                 "  \"user\"=\"%s\",\n" +
                 "  \"password\"=\"%s\"\n" +
-                ")", TABLE_ID, FE_HTTP, USER, PASSWORD);
+                ")", TABLE_ID, FE_HTTP, FE_JDBC, USER, PASSWORD);
         spark.sql(ddl);
         spark.sql("SELECT * FROM src").show(5);
         spark.stop();
@@ -99,6 +102,7 @@ public class ReadITTest {
         Dataset<Row> df = spark.read().format("starrocks")
                 .option("starrocks.table.identifier", TABLE_ID)
                 .option("starrocks.fenodes", FE_HTTP)
+                .option("starrocks.fe.jdbc.url", FE_JDBC)
                 .option("starrocks.user", USER)
                 .option("starrocks.password", PASSWORD)
                 .load();

--- a/src/test/java/com/starrocks/connector/spark/sql/SchemaITTest.java
+++ b/src/test/java/com/starrocks/connector/spark/sql/SchemaITTest.java
@@ -31,6 +31,7 @@ import org.apache.spark.sql.types.DecimalType;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +50,7 @@ import java.util.Map;
 import static com.starrocks.connector.spark.cfg.ConfigurationOptions.STARROCKS_REQUEST_AUTH_PASSWORD;
 import static com.starrocks.connector.spark.cfg.ConfigurationOptions.STARROCKS_REQUEST_AUTH_USER;
 
+@Ignore
 public class SchemaITTest {
     private static final Logger LOG = LoggerFactory.getLogger(SchemaITTest.class);
 
@@ -328,6 +330,7 @@ public class SchemaITTest {
         Dataset<Row> readDf = spark.read().format("starrocks")
                 .option("starrocks.table.identifier", TABLE_ID_WITHOUT_JSON)
                 .option("starrocks.fenodes", FE_HTTP)
+                .option("starrocks.fe.jdbc.url", FE_JDBC)
                 .option("user", USER)
                 .option("password", PASSWORD)
                 .load();

--- a/src/test/java/com/starrocks/connector/spark/sql/SchemaITTest.java
+++ b/src/test/java/com/starrocks/connector/spark/sql/SchemaITTest.java
@@ -1,0 +1,338 @@
+/*
+ * // Copyright 2021-present StarRocks, Inc. All rights reserved.
+ * //
+ * // Licensed under the Apache License, Version 2.0 (the "License");
+ * // you may not use this file except in compliance with the License.
+ * // You may obtain a copy of the License at
+ * //
+ * //     https://www.apache.org/licenses/LICENSE-2.0
+ * //
+ * // Unless required by applicable law or agreed to in writing, software
+ * // distributed under the License is distributed on an "AS IS" BASIS,
+ * // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * // See the License for the specific language governing permissions and
+ * // limitations under the License.
+ */
+
+package com.starrocks.connector.spark.sql;
+
+import com.starrocks.connector.spark.cfg.PropertiesSettings;
+import com.starrocks.connector.spark.rest.RestService;
+import com.starrocks.connector.spark.sql.conf.SimpleStarRocksConfig;
+import com.starrocks.connector.spark.sql.connect.StarRocksConnector;
+import com.starrocks.connector.spark.sql.schema.StarRocksSchema;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.DecimalType;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.starrocks.connector.spark.cfg.ConfigurationOptions.STARROCKS_REQUEST_AUTH_PASSWORD;
+import static com.starrocks.connector.spark.cfg.ConfigurationOptions.STARROCKS_REQUEST_AUTH_USER;
+
+public class SchemaITTest {
+    private static final Logger LOG = LoggerFactory.getLogger(SchemaITTest.class);
+
+// StarRocks Table with json
+//    CREATE TABLE `schema_test_with_json` (
+//        c0 BOOLEAN,
+//        c1 TINYINT,
+//        c2 SMALLINT,
+//        c3 INT,
+//        c4 BIGINT,
+//        c5 LARGEINT,
+//        c6 FLOAT,
+//        c7 DOUBLE,
+//        c8 DECIMAL(20, 0),
+//        c9 CHAR(10),
+//        c10 VARCHAR(100),
+//        c11 STRING,
+//        c12 DATE,
+//        c13 DATETIME
+//    ) ENGINE=OLAP
+//        PRIMARY KEY(`c0`, `c1`)
+//        COMMENT "OLAP"
+//        DISTRIBUTED BY HASH(`c0`)
+//        PROPERTIES (
+//        "replication_num" = "1"
+//        );
+
+// StarRocks Table without json
+//    CREATE TABLE `schema_test_without_json` (
+//        c0 BOOLEAN,
+//        c1 TINYINT,
+//        c2 SMALLINT,
+//        c3 INT,
+//        c4 BIGINT,
+//        c5 LARGEINT,
+//        c6 FLOAT,
+//        c7 DOUBLE,
+//        c8 DECIMAL(20, 0),
+//        c9 CHAR(10),
+//        c10 VARCHAR(100),
+//        c11 STRING,
+//        c12 DATE,
+//        c13 DATETIME
+//    ) ENGINE=OLAP
+//        PRIMARY KEY(`c0`, `c1`)
+//        COMMENT "OLAP"
+//        DISTRIBUTED BY HASH(`c0`)
+//        PROPERTIES (
+//        "replication_num" = "1"
+//        );
+
+
+    private static final String FE_HTTP = "127.0.0.1:11901";
+    private static final String FE_JDBC = "jdbc:mysql://127.0.0.1:11903";
+    private static final String DB = "starrocks";
+    private static final String TABLE_WITH_JSON = "schema_test_with_json";
+    private static final String TABLE_ID_WITH_JSON = DB + "." + TABLE_WITH_JSON;
+    private static final String TABLE_WITHOUT_JSON = "schema_test_without_json";
+    private static final String TABLE_ID_WITHOUT_JSON = DB + "." + TABLE_WITHOUT_JSON;
+    private static final String USER = "root";
+    private static final String PASSWORD = "";
+
+    @Test
+    public void testStarRocksSchema() throws Exception {
+        PropertiesSettings settings = new PropertiesSettings();
+        settings.setProperty("starrocks.fenodes", FE_HTTP);
+        settings.setProperty("starrocks.table.identifier", TABLE_ID_WITH_JSON);
+        settings.setProperty(STARROCKS_REQUEST_AUTH_USER, USER);
+        settings.setProperty(STARROCKS_REQUEST_AUTH_PASSWORD, PASSWORD);
+        com.starrocks.connector.spark.rest.models.Schema restSchema = RestService.getSchema(settings, LOG);
+
+        Map<String, String> options = new HashMap<>();
+        options.put("starrocks.fenodes", FE_HTTP);
+        options.put("starrocks.fe.jdbc.url", FE_JDBC);
+        options.put("starrocks.table.identifier", TABLE_ID_WITH_JSON);
+        options.put("starrocks.user", USER);
+        options.put("starrocks.password", PASSWORD);
+        SimpleStarRocksConfig config = new SimpleStarRocksConfig(options);
+        StarRocksSchema jdbcSchema = StarRocksConnector.getSchema(config);
+    }
+
+    @Test
+    public void testTime() {
+        // output 0001-01-01 00:00:00.0
+        System.out.println(Timestamp.valueOf("0000-01-01 00:00:00"));
+        // output 0000-01-01T00:00:00Z
+        System.out.println(Instant.parse("0000-01-01T00:00:00Z"));
+        // output 0001-01-01
+        System.out.println(Date.valueOf("0000-01-01"));
+        // output 0000-01-01
+        System.out.println(LocalDate.parse("0000-01-01"));
+    }
+
+    @Test
+    public void testSparkSchema() {
+        SparkSession spark = SparkSession
+                .builder()
+                .master("local[1]")
+                .appName("testSparkSchema")
+                .getOrCreate();
+
+        Row row = RowFactory.create(
+                true,
+                (byte) 1,
+                (short) 2,
+                3,
+                4L,
+                "5",
+                6.0f,
+                7.0,
+                BigDecimal.valueOf(8.0),
+                "9",
+                "10",
+                "11",
+                Date.valueOf("0000-01-01"),
+                Timestamp.valueOf("0000-01-01 00:00:00"),
+//                LocalDate.parse("0000-01-01"),
+//                Instant.parse("0000-01-01T00:00:00Z"),
+                "{\"key\": 1, \"value\": 2}"
+            );
+
+        StructType schema = new StructType(new StructField[]{
+                new StructField("c0", DataTypes.BooleanType, false, Metadata.empty()),
+                new StructField("c1", DataTypes.ByteType, false, Metadata.empty()),
+                new StructField("c2", DataTypes.ShortType, false, Metadata.empty()),
+                new StructField("c3", DataTypes.IntegerType, false, Metadata.empty()),
+                new StructField("c4", DataTypes.LongType, false, Metadata.empty()),
+                new StructField("c5", DataTypes.StringType, false, Metadata.empty()),
+                new StructField("c6", DataTypes.FloatType, false, Metadata.empty()),
+                new StructField("c7", DataTypes.DoubleType, false, Metadata.empty()),
+                new StructField("c8", new DecimalType(20, 0), false, Metadata.empty()),
+                new StructField("c9", DataTypes.StringType, false, Metadata.empty()),
+                new StructField("c10", DataTypes.StringType, false, Metadata.empty()),
+                new StructField("c11", DataTypes.StringType, false, Metadata.empty()),
+                new StructField("c12", DataTypes.DateType, false, Metadata.empty()),
+                new StructField("c13", DataTypes.TimestampType, false, Metadata.empty()),
+                new StructField("c14", DataTypes.StringType, false, Metadata.empty())
+        });
+
+        Dataset<Row> df = spark.createDataFrame(Collections.singletonList(row), schema);
+
+        df.write().format("console")
+                .option("truncate", "false")
+                .save();
+    }
+
+    @Test
+    public void testReadWriteWithJson() {
+        SparkSession spark = SparkSession
+                .builder()
+                .master("local[1]")
+                .appName("testWrite")
+                .getOrCreate();
+
+        List<Row> data = new ArrayList<>();
+        Row row = RowFactory.create(
+                true,
+                (byte) 1,
+                (short) 2,
+                3,
+                4L,
+                "5",
+                6.0f,
+                7.0,
+                BigDecimal.valueOf(8.0),
+                "9",
+                "10",
+                "11",
+                Date.valueOf("0000-01-01"),
+                Timestamp.valueOf("0000-01-01 00:00:00"),
+                "{\"key\": 1, \"value\": 2}"
+        );
+        data.add(row);
+
+        StructType schema = new StructType(new StructField[]{
+                new StructField("c0", DataTypes.BooleanType, false, Metadata.empty()),
+                new StructField("c1", DataTypes.ByteType, false, Metadata.empty()),
+                new StructField("c2", DataTypes.ShortType, false, Metadata.empty()),
+                new StructField("c3", DataTypes.IntegerType, false, Metadata.empty()),
+                new StructField("c4", DataTypes.LongType, false, Metadata.empty()),
+                new StructField("c5", DataTypes.StringType, false, Metadata.empty()),
+                new StructField("c6", DataTypes.FloatType, false, Metadata.empty()),
+                new StructField("c7", DataTypes.DoubleType, false, Metadata.empty()),
+                new StructField("c8", new DecimalType(20, 0), false, Metadata.empty()),
+                new StructField("c9", DataTypes.StringType, false, Metadata.empty()),
+                new StructField("c10", DataTypes.StringType, false, Metadata.empty()),
+                new StructField("c11", DataTypes.StringType, false, Metadata.empty()),
+                new StructField("c12", DataTypes.DateType, false, Metadata.empty()),
+                new StructField("c13", DataTypes.TimestampType, false, Metadata.empty()),
+                new StructField("c14", DataTypes.StringType, false, Metadata.empty())
+        });
+
+        Dataset<Row> df = spark.createDataFrame(data, schema);
+
+        Map<String, String> options = new HashMap<>();
+        options.put("starrocks.fenodes", FE_HTTP);
+        options.put("starrocks.fe.jdbc.url", FE_JDBC);
+        options.put("starrocks.table.identifier", TABLE_ID_WITH_JSON);
+        options.put("starrocks.user", USER);
+        options.put("starrocks.password", PASSWORD);
+
+        df.write().format("starrocks_writer")
+                .mode(SaveMode.Append)
+                .options(options)
+                .save();
+
+//        TODO read does not support json currently
+//        Dataset<Row> readDf = spark.read().format("starrocks")
+//                .option("starrocks.table.identifier", TABLE_ID_WITH_JSON)
+//                .option("starrocks.fenodes", FE_HTTP)
+//                .option("user", USER)
+//                .option("password", PASSWORD)
+//                .load();
+//        readDf.show(5);
+
+        spark.stop();
+    }
+
+    @Test
+    public void testReadWriteWithoutJson() throws Exception {
+        SparkSession spark = SparkSession
+                .builder()
+                .master("local[1]")
+                .appName("testWrite")
+                .getOrCreate();
+
+        List<Row> data = new ArrayList<>();
+        Row row = RowFactory.create(
+                true,
+                (byte) 1,
+                (short) 2,
+                3,
+                4L,
+                "5",
+                6.0f,
+                7.0,
+                BigDecimal.valueOf(8.0),
+                "9",
+                "10",
+                "11",
+                Date.valueOf("0000-01-01"),
+                Timestamp.valueOf("0000-01-01 00:00:00")
+        );
+        data.add(row);
+
+        StructType schema = new StructType(new StructField[]{
+                new StructField("c0", DataTypes.BooleanType, false, Metadata.empty()),
+                new StructField("c1", DataTypes.ByteType, false, Metadata.empty()),
+                new StructField("c2", DataTypes.ShortType, false, Metadata.empty()),
+                new StructField("c3", DataTypes.IntegerType, false, Metadata.empty()),
+                new StructField("c4", DataTypes.LongType, false, Metadata.empty()),
+                new StructField("c5", DataTypes.StringType, false, Metadata.empty()),
+                new StructField("c6", DataTypes.FloatType, false, Metadata.empty()),
+                new StructField("c7", DataTypes.DoubleType, false, Metadata.empty()),
+                new StructField("c8", new DecimalType(20, 0), false, Metadata.empty()),
+                new StructField("c9", DataTypes.StringType, false, Metadata.empty()),
+                new StructField("c10", DataTypes.StringType, false, Metadata.empty()),
+                new StructField("c11", DataTypes.StringType, false, Metadata.empty()),
+                new StructField("c12", DataTypes.DateType, false, Metadata.empty()),
+                new StructField("c13", DataTypes.TimestampType, false, Metadata.empty())
+        });
+
+        Dataset<Row> df = spark.createDataFrame(data, schema);
+
+        Map<String, String> options = new HashMap<>();
+        options.put("starrocks.fenodes", FE_HTTP);
+        options.put("starrocks.fe.jdbc.url", FE_JDBC);
+        options.put("starrocks.table.identifier", TABLE_ID_WITHOUT_JSON);
+        options.put("starrocks.user", USER);
+        options.put("starrocks.password", PASSWORD);
+
+        df.write().format("starrocks_writer")
+                .mode(SaveMode.Append)
+                .options(options)
+                .save();
+
+        Dataset<Row> readDf = spark.read().format("starrocks")
+                .option("starrocks.table.identifier", TABLE_ID_WITHOUT_JSON)
+                .option("starrocks.fenodes", FE_HTTP)
+                .option("user", USER)
+                .option("password", PASSWORD)
+                .load();
+        readDf.show(5);
+
+        spark.stop();
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This PR optimizes the date type mappings between starrocks and spark
* get starrocks table's schema via `information_schema.COLUMNS` for both read and write, and it's more standard and can return more detailed information than rest api `_schema`, such as `ORDINAL_POSITION` which can be used to determine the column position precisely
* map starrocks `DATE`/`DATETIME` to spark's `DateType`/`TimestampType` rather than `StringType`/`StringType` for both read and write
* map starrocks `BOOLEAN`/`TINYINT`/`SMALLINT` to spark's `BooleanType`/`ByteType`/`ShortType` rather than all `IntegerType`

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function