### PR TITLE
[Enhancement] Don't package mysql jdbc driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,12 +219,6 @@
             <artifactId>starrocks-thrift-sdk</artifactId>
             <version>1.0.1</version>
         </dependency>
-
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.49</version>
-        </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${sr_scala.version}</artifactId>
@@ -286,6 +280,12 @@
         </dependency>
 
         <!--Test-->
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>5.1.49</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-streaming_${sr_scala.version}</artifactId>

--- a/src/main/java/com/starrocks/connector/spark/sql/connect/StarRocksConnector.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/connect/StarRocksConnector.java
@@ -90,11 +90,11 @@ public class StarRocksConnector {
         try {
             Class.forName(MYSQL_80_DRIVER_NAME);
         } catch (ClassNotFoundException e) {
-            LOG.warn("Failed to find mysql driver {}", MYSQL_80_DRIVER_NAME, e);
+            LOG.warn("Failed to find mysql jdbc driver {}", MYSQL_80_DRIVER_NAME, e);
             try {
                 Class.forName(MYSQL_51_DRIVER_NAME);
             } catch (ClassNotFoundException ie) {
-                LOG.warn("Failed to find mysql driver {}", MYSQL_51_DRIVER_NAME, e);
+                LOG.warn("Failed to find mysql jdbc driver {}", MYSQL_51_DRIVER_NAME, e);
                 String msg = String.format("Can't find mysql jdbc driver, please download it and " +
                         "put it in your classpath manually. Note that the connector does not include " +
                         "the mysql driver since version 1.1.1 because of the limitation of GPL license " +

--- a/src/main/java/com/starrocks/connector/spark/sql/connect/StarRocksConnector.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/connect/StarRocksConnector.java
@@ -90,11 +90,9 @@ public class StarRocksConnector {
         try {
             Class.forName(MYSQL_80_DRIVER_NAME);
         } catch (ClassNotFoundException e) {
-            LOG.warn("Failed to find mysql jdbc driver {}", MYSQL_80_DRIVER_NAME, e);
             try {
                 Class.forName(MYSQL_51_DRIVER_NAME);
             } catch (ClassNotFoundException ie) {
-                LOG.warn("Failed to find mysql jdbc driver {}", MYSQL_51_DRIVER_NAME, e);
                 String msg = String.format("Can't find mysql jdbc driver, please download it and " +
                         "put it in your classpath manually. Note that the connector does not include " +
                         "the mysql driver since version 1.1.1 because of the limitation of GPL license " +


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
We use library `mysql-connector-java` to provide mysql jdbc driver, but it uses GPL license, and has some limitations for free usage. So we do not include it the connector jar anymore, and the user needs to download it and put it in classpath manually. The user can download it from MySQL site https://dev.mysql.com/downloads/connector/j/, or Maven Central https://repo1.maven.org/maven2/mysql/mysql-connector-java/

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function