### PR TITLE
[Feature] Support to load data to bitmap/hll columns

### DIFF
--- a/src/main/java/com/starrocks/connector/spark/sql/StarRocksTable.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/StarRocksTable.java
@@ -21,6 +21,7 @@ package com.starrocks.connector.spark.sql;
 
 import com.starrocks.connector.spark.sql.conf.StarRocksConfig;
 import com.starrocks.connector.spark.sql.conf.WriteStarRocksConfig;
+import com.starrocks.connector.spark.sql.schema.StarRocksSchema;
 import com.starrocks.connector.spark.sql.write.StarRocksWriteBuilder;
 import org.apache.spark.sql.connector.catalog.SupportsWrite;
 import org.apache.spark.sql.connector.catalog.Table;
@@ -47,16 +48,18 @@ public class StarRocksTable implements Table, SupportsWrite {
     );
 
     private final StructType schema;
+    private final StarRocksSchema starRocksSchema;
     private final StarRocksConfig config;
 
-    public StarRocksTable(StructType schema, Transform[] partitioning, StarRocksConfig config) {
+    public StarRocksTable(StructType schema, StarRocksSchema starRocksSchema, StarRocksConfig config) {
         this.schema = schema;
+        this.starRocksSchema = starRocksSchema;
         this.config = config;
     }
 
     @Override
     public WriteBuilder newWriteBuilder(LogicalWriteInfo info) {
-        WriteStarRocksConfig writeConfig = new WriteStarRocksConfig(config.getOriginOptions());
+        WriteStarRocksConfig writeConfig = new WriteStarRocksConfig(config.getOriginOptions(), schema, starRocksSchema);
         return new StarRocksWriteBuilder(info, writeConfig);
     }
 

--- a/src/main/java/com/starrocks/connector/spark/sql/conf/StarRocksConfig.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/conf/StarRocksConfig.java
@@ -43,4 +43,6 @@ public interface StarRocksConfig extends Serializable {
 
     @Nullable
     String[] getColumns();
+    @Nullable
+    String getColumnTypes();
 }

--- a/src/main/java/com/starrocks/connector/spark/sql/conf/StarRocksConfigBase.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/conf/StarRocksConfigBase.java
@@ -51,6 +51,14 @@ public abstract class StarRocksConfigBase implements StarRocksConfig {
     static final String KEY_REQUEST_CONNECT_TIMEOUT = STARROCKS_REQUEST_CONNECT_TIMEOUT_MS;
     static final String KEY_REQUEST_SOCKET_TIMEOUT = STARROCKS_REQUEST_READ_TIMEOUT_MS;
     public static final String KEY_COLUMNS = PREFIX + "columns";
+    // Specify the spark type of the column in starrocks if you want to customize the data type
+    // mapping between spark and starrocks. For example, there are two columns `c0`(DATE) and
+    // `c1`(DATETIME) in starrocks, you can set KEY_COLUMN_TYPES to "c0 STRING, c1 STRING" to
+    // map them to spark's STRING type, rather than the default DATE and TIMESTAMP. We use spark's
+    // StructType#fromDDL to parse the schema, so the format should follow the format of the output
+    // of StructType#toDDL. You only need to specify the columns that not follow the default
+    // data type mapping instead of all columns
+    public static final String KEY_COLUMN_TYPES = PREFIX + "column.types";
 
     protected final Map<String, String> originOptions;
 
@@ -62,6 +70,8 @@ public abstract class StarRocksConfigBase implements StarRocksConfig {
     private String table;
     @Nullable
     private String[] columns;
+    @Nullable
+    private String columnTypes;
     private int httpRequestRetries;
     private int httpRequestConnectTimeoutMs;
     private int httpRequestSocketTimeoutMs;
@@ -87,6 +97,7 @@ public abstract class StarRocksConfigBase implements StarRocksConfig {
             throw new RuntimeException(e);
         }
         this.columns = getArray(KEY_COLUMNS, null);
+        this.columnTypes = get(KEY_COLUMN_TYPES);
         this.httpRequestRetries = getInt(KEY_REQUEST_RETRIES, 3);
         this.httpRequestConnectTimeoutMs = getInt(KEY_REQUEST_CONNECT_TIMEOUT, 30000);
         this.httpRequestSocketTimeoutMs = getInt(KEY_REQUEST_SOCKET_TIMEOUT, 30000);
@@ -154,6 +165,12 @@ public abstract class StarRocksConfigBase implements StarRocksConfig {
     @Nullable
     public String[] getColumns() {
         return columns;
+    }
+
+    @Override
+    @Nullable
+    public String getColumnTypes() {
+        return columnTypes;
     }
 
     protected String get(final String key) {

--- a/src/main/java/com/starrocks/connector/spark/sql/schema/JSONRowStringConverter.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/schema/JSONRowStringConverter.java
@@ -34,10 +34,12 @@ public class JSONRowStringConverter extends AbstractRowStringConverter {
 
     private static final Logger LOG = LoggerFactory.getLogger(JSONRowStringConverter.class);
 
+    private final String[] streamLoadColumnNames;
     private final ObjectMapper mapper;
 
-    public JSONRowStringConverter(StructType schema, ZoneId timeZone) {
+    public JSONRowStringConverter(StructType schema, String[] streamLoadColumnNames, ZoneId timeZone) {
         super(schema, timeZone);
+        this.streamLoadColumnNames = streamLoadColumnNames;
         this.mapper = new ObjectMapper();
     }
 
@@ -48,10 +50,10 @@ public class JSONRowStringConverter extends AbstractRowStringConverter {
         }
 
         Map<String, Object> data = new HashMap<>();
-        for (StructField field : row.schema().fields()) {
-            int idx = row.fieldIndex(field.name());
-            if (!(field.nullable() && row.isNullAt(idx))) {
-                data.put(field.name(), valueConverters[idx].apply(row.get(idx)));
+        for (int i = 0; i < row.length(); i++) {
+            StructField field = row.schema().apply(i);
+            if (!(field.nullable() && row.isNullAt(i))) {
+                data.put(streamLoadColumnNames[i], valueConverters[i].apply(row.get(i)));
             }
         }
 

--- a/src/main/java/com/starrocks/connector/spark/sql/schema/StarRocksField.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/schema/StarRocksField.java
@@ -56,4 +56,12 @@ public class StarRocksField {
     public String getScale() {
         return scale;
     }
+
+    public boolean isBitmap() {
+        return "bitmap".equalsIgnoreCase(type);
+    }
+
+    public boolean isHll() {
+        return "hll".equalsIgnoreCase(type);
+    }
 }

--- a/src/main/java/com/starrocks/connector/spark/sql/write/StarRocksDataWriter.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/write/StarRocksDataWriter.java
@@ -59,7 +59,7 @@ public class StarRocksDataWriter implements DataWriter<InternalRow>, Serializabl
         if ("csv".equalsIgnoreCase(config.getFormat())) {
             this.converter = new CsvRowStringConverter(schema, config.getColumnSeparator(), config.getTimeZone());
         }  else if ("json".equalsIgnoreCase(config.getFormat())) {
-            this.converter = new JSONRowStringConverter(schema, config.getTimeZone());
+            this.converter = new JSONRowStringConverter(schema, config.getStreamLoadColumnNames(), config.getTimeZone());
         } else {
             throw new RuntimeException("Unsupported format " + config.getFormat());
         }

--- a/src/test/java/com/starrocks/connector/spark/sql/ITTestBase.java
+++ b/src/test/java/com/starrocks/connector/spark/sql/ITTestBase.java
@@ -103,7 +103,12 @@ public abstract class ITTestBase {
     }
 
     protected static List<List<Object>> scanTable(Connection dbConnector, String db, String table) throws SQLException {
-        try (PreparedStatement statement = dbConnector.prepareStatement(String.format("SELECT * FROM `%s`.`%s`", db, table))) {
+        String query = String.format("SELECT * FROM `%s`.`%s`", db, table);
+        return queryTable(dbConnector, query);
+    }
+
+    protected static List<List<Object>> queryTable(Connection dbConnector, String query) throws SQLException {
+        try (PreparedStatement statement = dbConnector.prepareStatement(query)) {
             try (ResultSet resultSet = statement.executeQuery()) {
                 List<List<Object>> results = new ArrayList<>();
                 int numColumns = resultSet.getMetaData().getColumnCount();
@@ -139,7 +144,11 @@ public abstract class ITTestBase {
         for (List<Object> row : expected) {
             StringJoiner joiner = new StringJoiner(",");
             for (Object col : row) {
-                joiner.add(col == null ? "null" : col.toString());
+                if (col instanceof Timestamp) {
+                    joiner.add(DATETIME_FORMATTER.format((Timestamp) col));
+                } else {
+                    joiner.add(col == null ? "null" : col.toString());
+                }
             }
             expectedRows.add(joiner.toString());
         }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [X] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Support to load data to bitmap/hll columns, and the main changes are
1. add option `starrocks.column.types` so that users can tell the connector how to map the bitmap/hll column to spark's data type. This option could be used generally if the data type mapping between starrocks and spark does not follow the default mapping
2. convert the data from spark to bitmap/hll using bitmpa/hll function
* for bitmap, convert `TINYINT`、`SMALLINT`、`INTEGER`、`BIGINT` in Spark to StarRocks `BITMAP` with to_bitmap function, and other types with bitmap_hash
* for hll, use hll_hash to convert spark data to hll 

An simple example

StarRocks DDL
```
CREATE TABLE `test`.`page_uv` (
  `page_id` INT NOT NULL COMMENT 'page ID',
  `visit_date` datetime NOT NULL COMMENT 'access time',
  `visit_users` BITMAP BITMAP_UNION NOT NULL COMMENT 'user ID'
) ENGINE=OLAP
AGGREGATE KEY(`page_id`, `visit_date`)
DISTRIBUTED BY HASH(`page_id`)
PROPERTIES (
  "replication_num" = "1"
);
```

Spark DDL
```
CREATE TABLE `page_uv`
USING starrocks
OPTIONS(
   "starrocks.fe.http.url"="127.0.0.1:8038",
   "starrocks.fe.jdbc.url"="jdbc:mysql://127.0.0.1:9038",
   "starrocks.table.identifier"="test.page_uv",
   "starrocks.user"="root",
   "starrocks.password"="",
   "starrocks.column.types"="visit_users BIGINT"
);
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function