### PR TITLE
[Enhancement] Optimize row-string converter

### DIFF
--- a/src/main/java/com/starrocks/connector/spark/sql/schema/CsvRowStringConverter.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/schema/CsvRowStringConverter.java
@@ -20,10 +20,7 @@
 package com.starrocks.connector.spark.sql.schema;
 
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.ZoneId;
 
@@ -44,8 +41,7 @@ public class CsvRowStringConverter extends AbstractRowStringConverter {
         String[] data = new String[row.length()];
         for (int i = 0; i < row.length(); i++) {
             if (!row.isNullAt(i)) {
-                StructField field = row.schema().fields()[i];
-                data[i] = convert(field.dataType(), row.get(i)).toString();
+                data[i] = valueConverters[i].apply(row.get(i)).toString();
             }
         }
 

--- a/src/main/java/com/starrocks/connector/spark/sql/schema/JSONRowStringConverter.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/schema/JSONRowStringConverter.java
@@ -51,7 +51,7 @@ public class JSONRowStringConverter extends AbstractRowStringConverter {
         for (StructField field : row.schema().fields()) {
             int idx = row.fieldIndex(field.name());
             if (!(field.nullable() && row.isNullAt(idx))) {
-                data.put(field.name(), convert(field.dataType(), row.get(idx)));
+                data.put(field.name(), valueConverters[idx].apply(row.get(idx)));
             }
         }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
When inserting into RS table, we need to convert ```InternalRow``` to json or csv string. Previously this was implemented via ```AbstractRowStringConverter.fromRow```. Even though the schema is definite, it still calls the ```convert``` method per row.

This PR has been tested on real data of 640 MB of orc data having almost 3 columns and 100 million rows, the Optimized stage with one partition is performed in 3 minutes compare to 9.1 minutes.  Here below flame graphs for 120-sec sample of the execution of the test query using Spark 3.3 in local mode. 

Before this PR:
<img width="1595" alt="graph-1" src="https://github.com/StarRocks/starrocks-connector-for-apache-spark/assets/17271682/4742c39c-5c2c-41cc-bd28-19ed3888ca7b">

spark ui
![spark-ui-1](https://github.com/StarRocks/starrocks-connector-for-apache-spark/assets/17271682/176128a2-af9f-4245-8efb-76d8c3ba2067)


After this PR:
<img width="1617" alt="graph-2" src="https://github.com/StarRocks/starrocks-connector-for-apache-spark/assets/17271682/8e1d8f8d-aac9-40b5-a2a5-ac93891b8135">

spark ui
![spark-ui-2](https://github.com/StarRocks/starrocks-connector-for-apache-spark/assets/17271682/1f4bf62c-4160-4697-8052-94a9d05e4c35)


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function