### PR TITLE
[Feature] Support to trigger flush according to the number of buffered rows

### DIFF
--- a/src/main/java/com/starrocks/connector/spark/sql/conf/WriteStarRocksConfig.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/conf/WriteStarRocksConfig.java
@@ -59,6 +59,8 @@ public class WriteStarRocksConfig extends StarRocksConfigBase {
     // The memory size used to buffer the rows before loading the data to StarRocks.
     // This can improve the performance for writing to starrocks.
     private static final String KEY_BUFFER_SIZE = WRITE_PREFIX + "buffer.size";
+    // The number of rows buffered before sending to StarRocks.
+    private static final String KEY_BUFFER_ROWS = WRITE_PREFIX + "buffer.rows";
     // Flush interval of the row batch in millisecond
     private static final String KEY_FLUSH_INTERVAL = WRITE_PREFIX + "flush.interval.ms";
     private static final String KEY_MAX_RETIES = WRITE_PREFIX + "max.retries";
@@ -79,6 +81,7 @@ public class WriteStarRocksConfig extends StarRocksConfigBase {
     private int scanFrequencyInMs = 50;
     private boolean enableTransactionStreamLoad = true;
     private long bufferSize = 104857600;
+    private int bufferRows = Integer.MAX_VALUE;
     private int flushInterval = 300000;
     private int maxRetries = 0;
     private int retryIntervalInMs = 10000;
@@ -110,6 +113,7 @@ public class WriteStarRocksConfig extends StarRocksConfigBase {
         scanFrequencyInMs = getInt(KEY_SCAN_FREQUENCY, 50);
         enableTransactionStreamLoad = getBoolean(KEY_ENABLE_TRANSACTION, true);
         bufferSize = Utils.byteStringAsBytes(get(KEY_BUFFER_SIZE, "100m"));
+        bufferRows = getInt(KEY_BUFFER_ROWS, Integer.MAX_VALUE);
         flushInterval = getInt(KEY_FLUSH_INTERVAL, 300000);
         maxRetries = getInt(KEY_MAX_RETIES, 3);
         retryIntervalInMs = getInt(KEY_RETRY_INTERVAL_MS, 10000);
@@ -234,6 +238,7 @@ public class WriteStarRocksConfig extends StarRocksConfigBase {
                 .columns(streamLoadColumnProperty)
                 .streamLoadDataFormat(dataFormat)
                 .chunkLimit(chunkLimit)
+                .maxBufferRows(bufferRows)
                 .build();
 
         StreamLoadProperties.Builder builder = StreamLoadProperties.builder()

--- a/src/test/java/com/starrocks/connector/spark/sql/ConfigurationITTest.java
+++ b/src/test/java/com/starrocks/connector/spark/sql/ConfigurationITTest.java
@@ -134,6 +134,7 @@ public class ConfigurationITTest extends ITTestBase {
         options.put("starrocks.write.scan-frequency.ms", "100");
         options.put("starrocks.write.enable.transaction-stream-load", "true");
         options.put("starrocks.write.buffer.size", "12k");
+        options.put("starrocks.write.buffer.rows", "1");
         options.put("starrocks.write.flush.interval.ms", "3000");
         options.put("starrocks.write.max.retries", "2");
         options.put("starrocks.write.retry.interval.ms", "1000");


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [X] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR adds a new option `starrocks.write.buffer.rows` to  control how to trigger flush according the number of buffered rows in a table. If the number of rows reaches the limitation, send these data to StarRocks.
This PR is based on https://github.com/StarRocks/starrocks-connector-for-apache-flink/pull/267

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function