### PR TITLE
[Enhancement] Override BatchWrite#useCommitCoordinator to run on DataBricks 13.1

### DIFF
--- a/src/main/java/com/starrocks/connector/spark/sql/write/StarRocksWrite.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/write/StarRocksWrite.java
@@ -48,6 +48,11 @@ public class StarRocksWrite implements BatchWrite, StreamingWrite {
     }
 
     @Override
+    public boolean useCommitCoordinator() {
+        return true;
+    }
+
+    @Override
     public void commit(WriterCommitMessage[] messages) {
         log.info("batch query `{}` commit", logicalInfo.queryId());
     }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

### What's the problem
Running spark connector on DataBricks 13.1 (powered by Spark 3.4.0) will fail because of the below exception. The version of spark connector is 1.1.0.
![image](https://github.com/StarRocks/starrocks-connector-for-apache-spark/assets/11382970/7e4cb232-c45c-4ec9-be2f-4c06b04d3061)

### How to solve it
DBR 13.1 is powered by Spark 3.4.0, but it also includes an additional improvement https://issues.apache.org/jira/browse/SPARK-42968. The improvement introduces a default method `useCommitCoordinator` in interface `StreamingWrite`. Because `StarRocksWrite` implements both interface `BatchWrite` and `StreamingWrite` which both have default method `useCommitCoordinator` on DBR 13.1, so it will leads default method conflict as the exception says. We could override the method in  `StarRocksWrite` to solve it. see https://www.geeksforgeeks.org/resolving-conflicts-during-multiple-inheritance-in-java/.

This improvement is introduced since Spark 3.5, but DBR introduce it in advance, and that's why the connector can run on community Spark 3.4, but failed on DBR 13.1. It seems DBR is not completely compatible with the community Spark.  

[1] [DataBrick 13.1 release note](https://docs.databricks.com/en/release-notes/runtime/13.1.html?_gl=1*uhpi3q*_gcl_au*NzExMTE3NDU4LjE2ODY3OTYyMjE.*_ga*NDAyNTc3MTY3LjE2Nzg3NzIxODg.*_ga_PQSEQ3RZQC*MTY5MzI5MzM5OS4yMS4xLjE2OTMyOTM5MjAuMjAuMC4w#databricks-runtime-131)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function