### PR TITLE
[Bugfix] Parse escape characters in column_seperator/row_delimiter of csv

### DIFF
--- a/src/main/java/com/starrocks/connector/spark/sql/conf/WriteStarRocksConfig.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/conf/WriteStarRocksConfig.java
@@ -21,6 +21,7 @@ package com.starrocks.connector.spark.sql.conf;
 
 import com.starrocks.connector.spark.sql.schema.StarRocksField;
 import com.starrocks.connector.spark.sql.schema.StarRocksSchema;
+import com.starrocks.data.load.stream.DelimiterParser;
 import com.starrocks.data.load.stream.StreamLoadDataFormat;
 import com.starrocks.data.load.stream.StreamLoadUtils;
 import com.starrocks.data.load.stream.properties.StreamLoadProperties;
@@ -127,8 +128,10 @@ public class WriteStarRocksConfig extends StarRocksConfigBase {
                         )
                 );
         format = originOptions.getOrDefault(KEY_PROPS_FORMAT, "CSV");
-        rowDelimiter = originOptions.getOrDefault(KEY_PROPS_ROW_DELIMITER, "\n");
-        columnSeparator = originOptions.getOrDefault(KEY_PROPS_COLUMN_SEPARATOR, "\t");
+        rowDelimiter = DelimiterParser.convertDelimiter(
+                originOptions.getOrDefault(KEY_PROPS_ROW_DELIMITER, "\n"));
+        columnSeparator = DelimiterParser.convertDelimiter(
+                originOptions.getOrDefault(KEY_PROPS_COLUMN_SEPARATOR, "\t"));
         String inferedFormat = inferFormatFromSchema(sparkSchema);
         if (inferedFormat != null) {
             format = inferedFormat;

--- a/src/test/java/com/starrocks/connector/spark/sql/ConfigurationITTest.java
+++ b/src/test/java/com/starrocks/connector/spark/sql/ConfigurationITTest.java
@@ -98,8 +98,8 @@ public class ConfigurationITTest extends ITTestBase {
     public void testWriteCsvConfiguration() throws Exception {
         Map<String, String> options = new HashMap<>();
         options.put("starrocks.write.properties.format", "csv");
-        options.put("starrocks.write.properties.row_delimiter", "|");
-        options.put("starrocks.write.properties.column_separator", ",");
+        options.put("starrocks.write.properties.row_delimiter", "\\x01");
+        options.put("starrocks.write.properties.column_separator", "\\x02");
         testWriteConfigurationBase(options);
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function