### PR TITLE
[BUGFIX] BuildScan need add quote to columns which is keyword

### DIFF
--- a/src/main/scala/com/starrocks/connector/spark/sql/StarrocksRelation.scala
+++ b/src/main/scala/com/starrocks/connector/spark/sql/StarrocksRelation.scala
@@ -79,7 +79,7 @@ private[sql] class StarrocksRelation(
           requiredColumns.map(Utils.quote).mkString(","))
     } else {
       paramWithScan += (ConfigurationOptions.STARROCKS_READ_FIELD ->
-          lazySchema.fields.map(f => f.name).mkString(","))
+          lazySchema.fields.map(f => Utils.quote(f.name)).mkString(","))
     }
 
     if (filters != null && filters.length > 0) {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
If user create table which contains keyword such like:
create table (
id string,
from string
)
then execute : select count(1) from table;
would occur parser error:

so add quote to it comfirm parser work well

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function