### PR TITLE
map starrocks bitmap type to array<int64> in sparksql

### DIFF
--- a/src/main/java/com/starrocks/connector/spark/sql/conf/WriteStarRocksConfig.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/conf/WriteStarRocksConfig.java
@@ -35,7 +35,6 @@ import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.util.Utils;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/main/java/com/starrocks/connector/spark/sql/schema/InferSchema.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/schema/InferSchema.java
@@ -23,11 +23,7 @@ import com.starrocks.connector.spark.exception.StarrocksException;
 import com.starrocks.connector.spark.sql.conf.SimpleStarRocksConfig;
 import com.starrocks.connector.spark.sql.conf.StarRocksConfig;
 import com.starrocks.connector.spark.sql.connect.StarRocksConnector;
-import org.apache.spark.sql.types.DataType;
-import org.apache.spark.sql.types.DataTypes;
-import org.apache.spark.sql.types.Metadata;
-import org.apache.spark.sql.types.StructField;
-import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.types.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -97,6 +93,8 @@ public final class InferSchema {
 
         return new StructField(field.getName(), dataType, true, Metadata.empty());
     }
+
+    public static DataType BitMapType = DataTypes.createArrayType(DataTypes.LongType);
     static DataType inferDataType(StarRocksField field) {
         String type = field.getType().toLowerCase(Locale.ROOT);
         switch (type) {
@@ -127,6 +125,8 @@ public final class InferSchema {
                 return DataTypes.DateType;
             case "datetime":
                 return DataTypes.TimestampType;
+            case "bitmap":
+                return BitMapType;
             default:
                 throw new UnsupportedOperationException(String.format(
                         "Unsupported starrocks type, column name: %s, data type: %s", field.getName(), field.getType()));

--- a/src/main/java/com/starrocks/connector/spark/sql/schema/InferSchema.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/schema/InferSchema.java
@@ -23,7 +23,12 @@ import com.starrocks.connector.spark.exception.StarrocksException;
 import com.starrocks.connector.spark.sql.conf.SimpleStarRocksConfig;
 import com.starrocks.connector.spark.sql.conf.StarRocksConfig;
 import com.starrocks.connector.spark.sql.connect.StarRocksConnector;
-import org.apache.spark.sql.types.*;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/src/main/scala/com/starrocks/connector/spark/rdd/AbstractStarrocksRDD.scala
+++ b/src/main/scala/com/starrocks/connector/spark/rdd/AbstractStarrocksRDD.scala
@@ -19,7 +19,7 @@
 
 package com.starrocks.connector.spark.rdd
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
 import com.starrocks.connector.spark.cfg.SparkSettings
@@ -34,7 +34,7 @@ private[spark] abstract class AbstractStarrocksRDD[T: ClassTag](
     extends RDD[T](sc, Nil) {
 
   override def getPartitions: Array[Partition] = {
-    starrocksPartitions.zipWithIndex.map { case (starrocksPartition, idx) =>
+    starrocksPartitions.asScala.zipWithIndex.map { case (starrocksPartition, idx) =>
       new StarrocksPartition(id, idx, starrocksPartition)
     }.toArray
   }
@@ -53,7 +53,7 @@ private[spark] abstract class AbstractStarrocksRDD[T: ClassTag](
    */
   @transient private[spark] lazy val starrocksCfg = {
     val cfg = new SparkSettings(sc.getConf)
-    cfg.merge(params)
+    cfg.merge(params.asJava)
   }
 
   @transient private[spark] lazy val starrocksPartitions = {

--- a/src/test/java/com/starrocks/connector/spark/sql/ITTestBase.java
+++ b/src/test/java/com/starrocks/connector/spark/sql/ITTestBase.java
@@ -24,6 +24,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.collection.Seq;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -176,7 +177,12 @@ public abstract class ITTestBase {
             StringJoiner joiner = new StringJoiner(",", "[", "]");
             ((List<?>) object).forEach(obj -> joiner.add(convertToStr(obj, true)));
             result = joiner.toString();
-        } else if (object instanceof Timestamp) {
+        } else if (object instanceof  Seq) {
+            // for scala array type
+            StringJoiner joiner = new StringJoiner(",", "[", "]");
+            ((Seq<?>) object).foreach(obj -> joiner.add(convertToStr(obj, true)));
+            result = joiner.toString();
+        }else if (object instanceof Timestamp) {
             result = DATETIME_FORMATTER.format((Timestamp) object);
         } else {
             result = object == null ? "null" : object.toString();


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Support bitmap type of starrocks in spark context.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This minor patch introduce starrocks bitmap type into spark as native array<int64> type, while limited but sill supports read from/write into in both direction.

Before this patch, it is possible and in some case more reliable for user to choose its mapping and walk around to interact with starrocks, like doing the trick manually like this implementation. 

Things to note that, as the BE do not natively support non-primitive arrow type such as Array in interaction, this patch use string as a intermedia before handing to user, which could produce huge memory impact if the resulting bitmap have a high rank. 

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function