### PR TITLE
[Feature] Sink supports LZ4 compression with json format

### DIFF
--- a/src/main/java/com/starrocks/connector/spark/sql/conf/WriteStarRocksConfig.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/conf/WriteStarRocksConfig.java
@@ -247,6 +247,7 @@ public class WriteStarRocksConfig extends StarRocksConfigBase {
                 .streamLoadDataFormat(dataFormat)
                 .chunkLimit(chunkLimit)
                 .maxBufferRows(bufferRows)
+                .addCommonProperties(properties)
                 .build();
 
         StreamLoadProperties.Builder builder = StreamLoadProperties.builder()


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
After StarRocks supports lz4 compression for stream load json format in https://github.com/StarRocks/starrocks/pull/43732, the connector can compress the json data before sending to StarRocks which will reduce the network traffic significantly.  In the test to load clickbench data to starrocks, the compression ratio can be ~8, and the load performance has a 3.64% degradation which is acceptable.
You can enable it with the following configuration
```
'starrocks.write.properties.format' = 'json'
'starrocks.write.properties.compression' = 'lz4_frame'
```

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function