### PR TITLE
[BugFix] Fix exception that java.lang.String is not a valid external type for DATE/TIMESTAMP type

### DIFF
--- a/src/main/java/com/starrocks/connector/spark/rest/RestService.java
+++ b/src/main/java/com/starrocks/connector/spark/rest/RestService.java
@@ -289,7 +289,7 @@ public class RestService implements Serializable {
         if (!StringUtils.isEmpty(cfg.getProperty(STARROCKS_FILTER_QUERY))) {
             sql += " where " + cfg.getProperty(STARROCKS_FILTER_QUERY);
         }
-        logger.debug("Query SQL Sending to StarRocks FE is: '{}'.", sql);
+        logger.info("Query SQL Sending to StarRocks FE is: '{}'.", sql);
 
         HttpPost httpPost = new HttpPost(getUriStr(cfg, logger) + QUERY_PLAN);
         String entity = "{\"sql\": \"" + sql + "\"}";

--- a/src/main/java/com/starrocks/connector/spark/serialization/RowBatch.java
+++ b/src/main/java/com/starrocks/connector/spark/serialization/RowBatch.java
@@ -168,15 +168,16 @@ public class RowBatch {
             for (int col = 0; col < fieldVectors.size(); col++) {
                 FieldVector curFieldVector = fieldVectors.get(col);
                 Types.MinorType mt = curFieldVector.getMinorType();
-                Field field = fieldMap.get(curFieldVector.getName());
-
-                String currentType;
-
-                if (field != null && field.getType().isPresent()) {
-                    currentType = field.getType().get();
-                } else {
-                    currentType = DataTypeUtils.map(mt);
+                String vectorName = curFieldVector.getName();
+                Field field = schema.get(col);
+                Preconditions.checkNotNull(field,
+                        "Can't find schema for arrow vector [%s] at index [%s]", vectorName, col);
+                if (!vectorName.isEmpty()) {
+                    Preconditions.checkState(vectorName.equals(field.getName()),
+                            "The column at [%s] has inconsistent column names between schema [%s] " +
+                                    "and arrow vector [%s]", col, field.getName(), vectorName);
                 }
+                String currentType = field.getType().orElseGet(() -> DataTypeUtils.map(mt));
 
                 switch (currentType) {
                     case "NULL_TYPE":


### PR DESCRIPTION
## What type of PR is this：
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
### How to produce

StarRocks
```
CREATE TABLE test (
        c0 INT,
        c1 STRING,
        c2 DATE
);

INSERT INTO test VALUES (1, '1', '2024-04-20');
```

Spark SQL
```
SELECT c1, c2 WHERE c0 = 1;
```

exception
```
Caused by: java.lang.RuntimeException: java.lang.String is not a valid external type for schema of date
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.StaticInvoke_1$(Unknown Source)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.writeFields_0_0$(Unknown Source)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.apply(Unknown Source)
	at org.apache.spark.sql.catalyst.encoders.ExpressionEncoder$Serializer.apply(ExpressionEncoder.scala:207)
	... 19 more

```

### Reason
If the predicate columns are not in select columns, the arrow vector names returned by StarRocks will be empty, and the connector can't find the right spark data type for the selected column because the connector relies on column names to map arrow column to spark column. This will be a problem if the StarRocks column type is date/datetime. The arrow type for the column is varchar, but the spark type is date/timestmap. Because can't find the right spark type, so the connector will convert it to java.lang.String which will raise the RuntimeException.
### How to fix
map arrow column to spark column according to the column index rather than the name so that could find the right spark data type

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function