### PR TITLE
[Enhancement] Support to configure socket timeout for write

### DIFF
--- a/src/main/java/com/starrocks/connector/spark/sql/conf/WriteStarRocksConfig.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/conf/WriteStarRocksConfig.java
@@ -51,6 +51,7 @@ public class WriteStarRocksConfig extends StarRocksConfigBase {
     public static final String WRITE_PREFIX = PREFIX + "write.";
     // The prefix of the stream load label. Available values are within [-_A-Za-z0-9]
     private static final String KEY_LABEL_PREFIX = WRITE_PREFIX + "label.prefix";
+    private static final String KEY_SOCKET_TIMEOUT = WRITE_PREFIX + "socket.timeout.ms";
     // Timeout in millisecond to wait for 100-continue response from FE
     private static final String KEY_WAIT_FOR_CONTINUE_TIMEOUT = WRITE_PREFIX + "wait-for-continue.timeout.ms";
     // Data chunk size in a http request for stream load
@@ -77,6 +78,7 @@ public class WriteStarRocksConfig extends StarRocksConfigBase {
     private static final String KEY_PARTITION_COLUMNS = WRITE_PREFIX + "partition.columns";
 
     private String labelPrefix = "spark";
+    private int socketTimeoutMs = -1;
     private int waitForContinueTimeoutMs = 30000;
     // Only support to write to one table, and one thread is enough
     private int ioThreadCount = 1;
@@ -118,6 +120,7 @@ public class WriteStarRocksConfig extends StarRocksConfigBase {
 
     private void load(StructType sparkSchema) {
         labelPrefix = get(KEY_LABEL_PREFIX, "spark");
+        socketTimeoutMs = getInt(KEY_SOCKET_TIMEOUT, -1);
         waitForContinueTimeoutMs = getInt(KEY_WAIT_FOR_CONTINUE_TIMEOUT, 30000);
         chunkLimit = Utils.byteStringAsBytes(get(KEY_CHUNK_LIMIT, "3g"));
         scanFrequencyInMs = getInt(KEY_SCAN_FREQUENCY, 50);
@@ -270,6 +273,7 @@ public class WriteStarRocksConfig extends StarRocksConfigBase {
                 .username(getUsername())
                 .password(getPassword())
                 .connectTimeout(getHttpRequestConnectTimeoutMs())
+                .socketTimeout(socketTimeoutMs)
                 .waitForContinueTimeoutMs(waitForContinueTimeoutMs)
                 .ioThreadCount(ioThreadCount)
                 .scanningFrequency(scanFrequencyInMs)


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
Add a configuration `starrocks.write.socket.timeout.ms`. It's the timeout in milliseconds that the http client waits for data or, put differently, a maximum period inactivity between two consecutive data packets. The default value -1 is same as that of apache http client which is interpreted as undefined (system default if applicable). A timeout value of zero is interpreted as an infinite timeout. You can use this option to fail the stream load from the connector side if the http client does not receive response from StarRocks before timeout. The other option `starrocks.write.properties.timeout` take effects on the StarRocks side, but the response to the client may delay in some unexpected cases. If you want to have a strict timeout from the connector side, you can set this option to an acceptable value.

After reaching the timeout, there will be an exception like this
```
java.net.SocketTimeoutException: Read timed out
	at java.net.SocketInputStream.socketRead0(Native Method) ~[?:1.8.0_345]
	at java.net.SocketInputStream.socketRead(SocketInputStream.java:116) ~[?:1.8.0_345]
	at java.net.SocketInputStream.read(SocketInputStream.java:171) ~[?:1.8.0_345]
	at java.net.SocketInputStream.read(SocketInputStream.java:141) ~[?:1.8.0_345]
	at com.starrocks.streamload.shade.org.apache.http.impl.conn.LoggingInputStream.read(LoggingInputStream.java:84) ~[starrocks-stream-load-sdk-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at com.starrocks.streamload.shade.org.apache.http.impl.io.SessionInputBufferImpl.streamRead(SessionInputBufferImpl.java:137) ~[starrocks-stream-load-sdk-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at com.starrocks.streamload.shade.org.apache.http.impl.io.SessionInputBufferImpl.fillBuffer(SessionInputBufferImpl.java:153) ~[starrocks-stream-load-sdk-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at com.starrocks.streamload.shade.org.apache.http.impl.io.SessionInputBufferImpl.readLine(SessionInputBufferImpl.java:280) ~[starrocks-stream-load-sdk-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at com.starrocks.streamload.shade.org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:138) ~[starrocks-stream-load-sdk-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at com.starrocks.streamload.shade.org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:56) ~[starrocks-stream-load-sdk-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at com.starrocks.streamload.shade.org.apache.http.impl.io.AbstractMessageParser.parse(AbstractMessageParser.java:259) ~[starrocks-stream-load-sdk-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at com.starrocks.streamload.shade.org.apache.http.impl.DefaultBHttpClientConnection.receiveResponseHeader(DefaultBHttpClientConnection.java:163) ~[starrocks-stream-load-sdk-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at com.starrocks.streamload.shade.org.apache.http.impl.conn.CPoolProxy.receiveResponseHeader(CPoolProxy.java:157) ~[starrocks-stream-load-sdk-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at com.starrocks.streamload.shade.org.apache.http.protocol.HttpRequestExecutor.doReceiveResponse(HttpRequestExecutor.java:273) ~[starrocks-stream-load-sdk-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at com.starrocks.streamload.shade.org.apache.http.protocol.HttpRequestExecutor.execute(HttpRequestExecutor.java:125) ~[starrocks-stream-load-sdk-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at com.starrocks.streamload.shade.org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:272) ~[starrocks-stream-load-sdk-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at com.starrocks.streamload.shade.org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:186) ~[starrocks-stream-load-sdk-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at com.starrocks.streamload.shade.org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:89) ~[starrocks-stream-load-sdk-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at com.starrocks.streamload.shade.org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110) ~[starrocks-stream-load-sdk-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at com.starrocks.streamload.shade.org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185) ~[starrocks-stream-load-sdk-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at com.starrocks.streamload.shade.org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83) ~[starrocks-stream-load-sdk-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at com.starrocks.streamload.shade.org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:108) ~[starrocks-stream-load-sdk-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function