### PR TITLE
[BugFix] Fix wrong pushdown filter in datasource v2

### DIFF
--- a/src/main/scala/com/starrocks/connector/spark/read/StarRocksBatchScan.scala
+++ b/src/main/scala/com/starrocks/connector/spark/read/StarRocksBatchScan.scala
@@ -68,9 +68,12 @@ class StarRocksScanBuilder(tableName: String,
       .mkString(" and ")
     // only for test
     predicateWhereClauseForTest = predicateWhereClause
-
+    val mySqlDialect = JdbcDialects.get("jdbc:mysql")
+    val filterWhereClause: String = {
+      predicates.flatMap(mySqlDialect.compileExpression(_)).map(p => s"($p)").mkString(" AND ")
+    }
     // pass filter column to BE
-    config.setProperty(STARROCKS_FILTER_QUERY, predicateWhereClause)
+    config.setProperty(STARROCKS_FILTER_QUERY, filterWhereClause)
 
     supportedPredicates = supported
     supported

--- a/src/main/scala/com/starrocks/connector/spark/read/StarRocksBatchScan.scala
+++ b/src/main/scala/com/starrocks/connector/spark/read/StarRocksBatchScan.scala
@@ -47,7 +47,6 @@ class StarRocksScanBuilder(tableName: String,
   private var readSchema: StructType = schema
 
   private lazy val dialect = JdbcDialects.get("jdbc:mysql")
-  private lazy val sqlBuilder: V2ExpressionSQLBuilder = new V2ExpressionSQLBuilder
 
   override def pruneColumns(requiredSchema: StructType): Unit = {
     val requiredCols = requiredSchema.map(_.name)

--- a/src/test/java/com/starrocks/connector/spark/sql/ReadWriteITTest.java
+++ b/src/test/java/com/starrocks/connector/spark/sql/ReadWriteITTest.java
@@ -40,10 +40,7 @@ import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Statement;
 import java.sql.Timestamp;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/com/starrocks/connector/spark/sql/ReadWriteITTest.java
+++ b/src/test/java/com/starrocks/connector/spark/sql/ReadWriteITTest.java
@@ -1370,4 +1370,64 @@ public class ReadWriteITTest extends ITTestBase {
         spark.stop();
 
     }
+
+    @Test
+    public void testSqlWithDatetimePredicate() throws Exception {
+        String tableName = "testSql_" + genRandomUuid();
+
+        String createStarRocksTable =
+                String.format("CREATE TABLE `%s`.`%s` (" +
+                                "id INT," +
+                                "name STRING," +
+                                "score INT," +
+                                "modified_time DATETIME" +
+                                ") ENGINE=OLAP " +
+                                "PRIMARY KEY(`id`) " +
+                                "DISTRIBUTED BY HASH(`id`) BUCKETS 2 " +
+                                "PROPERTIES (" +
+                                "\"replication_num\" = \"1\"" +
+                                ")",
+                        DB_NAME, tableName);
+        executeSrSQL(createStarRocksTable);
+
+
+        try (Statement statement = DB_CONNECTION.createStatement()) {
+            statement.execute("insert into " + DB_NAME + "." + tableName + " VALUES (1, 'Tom', 3, '2025-07-02 07:35:58'), (2, 'Jerry', 4, '2025-06-02 07:35:58')");
+        }
+
+        SparkSession spark = SparkSession
+                .builder()
+                .config(new SparkConf()
+                        .set("spark.sql.catalog.sr", "com.starrocks.connector.spark.catalog.StarRocksCatalog")
+                        .set("spark.sql.catalog.sr.starrocks.fe.http.url", FE_HTTP)
+                        .set("spark.sql.catalog.sr.starrocks.fe.jdbc.url", FE_JDBC)
+                        .set("spark.sql.catalog.sr.starrocks.user", USER)
+                        .set("spark.sql.catalog.sr.starrocks.password", PASSWORD)
+                )
+                .master("local[1]")
+                .appName("testSqlWithDatetimePredicate")
+                .getOrCreate();
+
+        String querySql = String.format(
+                "select id, name, score, modified_time from sr.%s.%s where modified_time > '2025-07-02 00:00:00'",
+                DB_NAME, tableName
+        );
+
+        List<Row> readRows = spark.sql(querySql)
+                .collectAsList();
+        Assertions.assertEquals(1, readRows.size());
+
+        GenericRowWithSchema row = (GenericRowWithSchema) readRows.get(0);
+        Assertions.assertEquals(0, row.schema().fieldIndex("id"));
+        Assertions.assertEquals(1, row.schema().fieldIndex("name"));
+        Assertions.assertEquals(2, row.schema().fieldIndex("score"));
+        Assertions.assertEquals(3, row.schema().fieldIndex("modified_time"));
+
+        List<List<Object>> expectedData = new ArrayList<>();
+        expectedData.add(Arrays.asList(1, "Tom", 3, Timestamp.valueOf("2025-07-02 07:35:58")));
+
+        verifyRows(expectedData, readRows);
+        spark.stop();
+
+    }
 }

--- a/src/test/java/com/starrocks/connector/spark/sql/ReadWriteITTest.java
+++ b/src/test/java/com/starrocks/connector/spark/sql/ReadWriteITTest.java
@@ -1389,8 +1389,7 @@ public class ReadWriteITTest extends ITTestBase {
                                 ")",
                         DB_NAME, tableName);
         executeSrSQL(createStarRocksTable);
-
-
+        
         try (Statement statement = DB_CONNECTION.createStatement()) {
             statement.execute("insert into " + DB_NAME + "." + tableName + " VALUES (1, 'Tom', 3, '2025-07-02 07:35:58'), (2, 'Jerry', 4, '2025-06-02 07:35:58')");
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
_timestamp：

 DATETIME type in StarRocks

The query:

SELECT * FROM starrocks_table WHERE _timestamp >= '2025-06-13' AND _timestamp < '2025-06-14'

results in the following pushed predicates:
(_timestamp IS NOT NULL) and (_timestamp >= 1749772800000000) and (_timestamp < 1749859200000000).

However, these predicates are in the Spark dialect, and when passed to the StarRocks Backend (BE), users get an empty result, because the timestamp values are not correctly interpreted by StarRocks.

Fixes the issue above. 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function