### PR TITLE
[BugFix] Fix retry logic for backend client

### DIFF
--- a/src/main/java/com/starrocks/connector/spark/backend/BackendClient.java
+++ b/src/main/java/com/starrocks/connector/spark/backend/BackendClient.java
@@ -142,8 +142,9 @@ public class BackendClient {
                 }
                 return result;
             } catch (TException e) {
-                logger.warn("Open scanner from {} failed.", routing, e);
+                logger.warn("Open scanner from {} failed, attempt to reconnect.", routing, e);
                 ex = e;
+                reopenIfNeeded(attempt, retries, e);
             }
         }
         logger.error(ErrorMessages.CONNECT_FAILED_MESSAGE, routing);
@@ -179,8 +180,9 @@ public class BackendClient {
                 }
                 return result;
             } catch (TException e) {
-                logger.warn("Get next from {} failed.", routing, e);
+                logger.warn("Get next from {} failed, attempt to reconnect.", routing, e);
                 ex = e;
+                reopenIfNeeded(attempt, retries, e);
             }
         }
         if (result != null && (TStatusCode.OK != (result.getStatus().getStatus_code()))) {
@@ -223,10 +225,28 @@ public class BackendClient {
                 }
                 break;
             } catch (TException e) {
-                logger.warn("Close scanner from {} failed.", routing, e);
+                logger.warn("Close scanner from {} failed, attempt to reconnect.", routing, e);
+                reopenIfNeeded(attempt, retries, e);
             }
         }
         logger.info("CloseScanner to StarRocks BE '{}' success.", routing);
         close();
+    }
+
+    // when TException occurs, try to reconnect
+    private void reopenIfNeeded(int attempt, int maxRetries, Exception e) {
+        if (!(e instanceof TException)) {
+            return;
+        }
+        // Close the broken connection and try to reconnect
+        close();
+        // For the last attempt, no need to open
+        if (attempt < maxRetries - 1) {
+            try {
+                open();
+            } catch (ConnectedFailedException connEx) {
+                logger.warn("Reconnect to {} failed.", routing, connEx);
+            }
+        }
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
While backend client encountered socket exception, the socket might have been broken before attempt. 


```
2025-11-26 17:10:45 WARN [Executor task launch worker for task 0.0 in stage 0.0 (TID 0)] BackendClient:184 - Get next from StarRocks BE{host='10.66.130.64', port=9060} failed.
com.starrocks.shaded.org.apache.thrift.transport.TTransportException: java.net.SocketException: Connection reset
at com.starrocks.shaded.org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:178) ~[1.0-batch-testsr.jar:?]
at com.starrocks.shaded.org.apache.thrift.transport.TTransport.readAll(TTransport.java:109) ~[1.0-batch-testsr.jar:?]
at com.starrocks.shaded.org.apache.thrift.protocol.TBinaryProtocol.readAll(TBinaryProtocol.java:463) ~[1.0-batch-testsr.jar:?]
at com.starrocks.shaded.org.apache.thrift.protocol.TBinaryProtocol.readI32(TBinaryProtocol.java:361) ~[1.0-batch-testsr.jar:?]
at com.starrocks.shaded.org.apache.thrift.protocol.TBinaryProtocol.readMessageBegin(TBinaryProtocol.java:244) ~[1.0-batch-testsr.jar:?]
at com.starrocks.shaded.org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:77) ~[1.0-batch-testsr.jar:?]
at com.starrocks.connector.thrift.TStarrocksExternalService$Client.recv_get_next(TStarrocksExternalService.java:117) ~[1.0-batch-testsr.jar:?]
at com.starrocks.connector.thrift.TStarrocksExternalService$Client.get_next(TStarrocksExternalService.java:104) ~[1.0-batch-testsr.jar:?]
at com.starrocks.connector.spark.backend.BackendClient.getNext(BackendClient.java:172) ~[1.0-batch-testsr.jar:?]
at com.starrocks.connector.spark.rdd.ScalaValueReader.hasNext(ScalaValueReader.scala:197) ~[1.0-batch-testsr.jar:?]
at com.starrocks.connector.spark.rdd.AbstractStarrocksRDDIterator.hasNext(AbstractStarrocksRDDIterator.scala:58) ~[1.0-batch-testsr.jar:?]
at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:460) ~[scala-library-2.12.15.jar:?]
at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.hashAgg_doAggregateWithoutKey_0$(Unknown Source) ~[?:?]
at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source) ~[?:?]
at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43) ~[spark-sql_2.12-3.3.1-emr.jar:3.3.1-emr]
at org.apache.spark.sql.execution.WholeStageCodegenExec$$anon$1.hasNext(WholeStageCodegenExec.scala:760) ~[spark-sql_2.12-3.3.1-emr.jar:3.3.1-emr]
at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:460) ~[scala-library-2.12.15.jar:?]
at org.apache.spark.shuffle.celeborn.SortBasedShuffleWriter.fastWrite0(SortBasedShuffleWriter.java:258) ~[celeborn-client-spark-3-shaded_2.12-0.5.3-20250217.052700-9.jar:?]
at org.apache.spark.shuffle.celeborn.SortBasedShuffleWriter.doWrite(SortBasedShuffleWriter.java:217) ~[celeborn-client-spark-3-shaded_2.12-0.5.3-20250217.052700-9.jar:?]
at org.apache.spark.shuffle.celeborn.SortBasedShuffleWriter.write(SortBasedShuffleWriter.java:233) ~[celeborn-client-spark-3-shaded_2.12-0.5.3-20250217.052700-9.jar:?]
at org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:59) ~[spark-core_2.12-3.3.1-emr.jar:3.3.1-emr]
at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:99) ~[spark-core_2.12-3.3.1-emr.jar:3.3.1-emr]
at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:52) ~[spark-core_2.12-3.3.1-emr.jar:3.3.1-emr]
at org.apache.spark.scheduler.Task.run(Task.scala:136) ~[spark-core_2.12-3.3.1-emr.jar:3.3.1-emr]
at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:555) ~[spark-core_2.12-3.3.1-emr.jar:3.3.1-emr]
at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1520) ~[spark-core_2.12-3.3.1-emr.jar:3.3.1-emr]
at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:558) ~[spark-core_2.12-3.3.1-emr.jar:3.3.1-emr]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_432]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_432]
at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_432]
Caused by: java.net.SocketException: Connection reset
at java.net.SocketInputStream.read(SocketInputStream.java:210) ~[?:1.8.0_432]
at java.net.SocketInputStream.read(SocketInputStream.java:141) ~[?:1.8.0_432]
at java.io.BufferedInputStream.fill(BufferedInputStream.java:246) ~[?:1.8.0_432]
at java.io.BufferedInputStream.read1(BufferedInputStream.java:286) ~[?:1.8.0_432]
at java.io.BufferedInputStream.read(BufferedInputStream.java:345) ~[?:1.8.0_432]
at com.starrocks.shaded.org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:176) ~[1.0-batch-testsr.jar:?]
... 29 more

````

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function