### PR TITLE
[Feature] Support column comment in catalog DESC and SHOW CREATE TABLE

### DIFF
--- a/src/main/java/com/starrocks/connector/spark/sql/connect/StarRocksConnector.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/connect/StarRocksConnector.java
@@ -46,7 +46,8 @@ public class StarRocksConnector {
     private static Logger logger = LoggerFactory.getLogger(StarRocksConnector.class);
 
     private static final String TABLE_SCHEMA_QUERY =
-            "SELECT `COLUMN_NAME`, `ORDINAL_POSITION`, `COLUMN_KEY`, `COLUMN_TYPE`, `COLUMN_SIZE`, `DECIMAL_DIGITS` "
+            "SELECT `COLUMN_NAME`, `ORDINAL_POSITION`, `COLUMN_KEY`, `COLUMN_TYPE`, `COLUMN_SIZE`, `DECIMAL_DIGITS`, "
+                    + "`COLUMN_COMMENT` "
                     + "FROM `information_schema`.`COLUMNS` WHERE `TABLE_SCHEMA`=? AND `TABLE_NAME`=?;";
     private static final String ALL_DBS_QUERY = "show databases;";
     private static final String LOAD_DB_QUERY =
@@ -74,7 +75,8 @@ public class StarRocksConnector {
                     Integer.parseInt(columnValue.get("ORDINAL_POSITION")),
                     Optional.ofNullable(columnValue.get("COLUMN_SIZE")).map(Integer::parseInt).orElse(null),
                     Optional.ofNullable(columnValue.get("COLUMN_SIZE")).map(Integer::parseInt).orElse(null),
-                    Optional.ofNullable(columnValue.get("DECIMAL_DIGITS")).map(Integer::parseInt).orElse(null));
+                    Optional.ofNullable(columnValue.get("DECIMAL_DIGITS")).map(Integer::parseInt).orElse(null),
+                    columnValue.get("COLUMN_COMMENT"));
             columns.add(field);
             if ("PRI".equals(columnValue.get("COLUMN_KEY"))) {
                 pks.add(field);

--- a/src/main/java/com/starrocks/connector/spark/sql/schema/InferSchema.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/schema/InferSchema.java
@@ -81,7 +81,7 @@ public final class InferSchema {
                 String lowerCaseName = fieldName.toLowerCase(Locale.ROOT);
                 StructField custom = customTypes.get(lowerCaseName);
                 if (custom != null) {
-                    fields.add(custom);
+                    fields.add(applyComment(custom, field.getComment()));
                     unmatchedOverrides.remove(lowerCaseName);
                     continue;
                 }
@@ -112,13 +112,18 @@ public final class InferSchema {
 
     static StructField inferStructField(StarRocksField field) {
         DataType dataType = inferDataType(field);
+        return applyComment(new StructField(field.getName(), dataType, true, Metadata.empty()), field.getComment());
+    }
 
-        String comment = field.getComment();
-        Metadata metadata = (comment == null || comment.isEmpty())
-                ? Metadata.empty()
-                : new MetadataBuilder().putString("comment", comment).build();
-
-        return new StructField(field.getName(), dataType, true, metadata);
+    static StructField applyComment(StructField field, String comment) {
+        if (comment == null || comment.isEmpty()) {
+            return field;
+        }
+        Metadata metadata = new MetadataBuilder()
+                .withMetadata(field.metadata())
+                .putString("comment", comment)
+                .build();
+        return new StructField(field.name(), field.dataType(), field.nullable(), metadata);
     }
 
     static DataType inferDataType(StarRocksField field) {

--- a/src/main/java/com/starrocks/connector/spark/sql/schema/InferSchema.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/schema/InferSchema.java
@@ -26,6 +26,7 @@ import com.starrocks.connector.spark.sql.connect.StarRocksConnector;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.MetadataBuilder;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
@@ -112,7 +113,12 @@ public final class InferSchema {
     static StructField inferStructField(StarRocksField field) {
         DataType dataType = inferDataType(field);
 
-        return new StructField(field.getName(), dataType, true, Metadata.empty());
+        String comment = field.getComment();
+        Metadata metadata = (comment == null || comment.isEmpty())
+                ? Metadata.empty()
+                : new MetadataBuilder().putString("comment", comment).build();
+
+        return new StructField(field.getName(), dataType, true, metadata);
     }
 
     static DataType inferDataType(StarRocksField field) {

--- a/src/main/java/com/starrocks/connector/spark/sql/schema/StarRocksField.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/schema/StarRocksField.java
@@ -32,14 +32,21 @@ public class StarRocksField implements Serializable {
 
     private Integer precision;
     private Integer scale;
+    private String comment;
 
     public StarRocksField(String name, String type, int ordinalPosition, Integer size, Integer precision, Integer scale) {
+        this(name, type, ordinalPosition, size, precision, scale, null);
+    }
+
+    public StarRocksField(String name, String type, int ordinalPosition, Integer size, Integer precision, Integer scale,
+                          String comment) {
         this.name = name;
         this.type = type;
         this.ordinalPosition = ordinalPosition;
         this.size = size;
         this.precision = precision;
         this.scale = scale;
+        this.comment = comment;
     }
 
     public String getName() {
@@ -64,6 +71,10 @@ public class StarRocksField implements Serializable {
 
     public Integer getScale() {
         return scale;
+    }
+
+    public String getComment() {
+        return comment;
     }
 
     public boolean isJson() {

--- a/src/test/java/com/starrocks/connector/spark/sql/schema/InferSchemaTest.java
+++ b/src/test/java/com/starrocks/connector/spark/sql/schema/InferSchemaTest.java
@@ -22,6 +22,7 @@ package com.starrocks.connector.spark.sql.schema;
 import com.starrocks.connector.spark.sql.conf.SimpleStarRocksConfig;
 import com.starrocks.connector.spark.sql.conf.StarRocksConfigBase;
 import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.Assert;
@@ -53,6 +54,20 @@ public class InferSchemaTest {
         StructType identifierType = (StructType) identifier.dataType();
         Assert.assertEquals(DataTypes.StringType, identifierType.apply("type").dataType());
         Assert.assertEquals(DataTypes.StringType, identifierType.apply("id").dataType());
+    }
+
+    @Test
+    public void testColumnCommentInMetadata() {
+        List<StarRocksField> fields = Arrays.asList(
+                new StarRocksField("user_id", "bigint", 1, null, null, null, "user id"),
+                new StarRocksField("email", "varchar", 2, null, null, null, null)
+        );
+        StarRocksSchema schema = new StarRocksSchema(fields);
+
+        StructType result = InferSchema.inferSchema(schema, new SimpleStarRocksConfig(new HashMap<>()));
+
+        Assert.assertEquals("user id", result.apply("user_id").metadata().getString("comment"));
+        Assert.assertEquals(Metadata.empty(), result.apply("email").metadata());
     }
 }
 

--- a/src/test/java/com/starrocks/connector/spark/sql/schema/InferSchemaTest.java
+++ b/src/test/java/com/starrocks/connector/spark/sql/schema/InferSchemaTest.java
@@ -36,6 +36,23 @@ import java.util.Map;
 public class InferSchemaTest {
 
     @Test
+    public void testStructOverridePreservesComment() {
+        List<StarRocksField> fields = Arrays.asList(
+                new StarRocksField("identifier", "struct", 1, null, null, null, "nested identifier")
+        );
+        StarRocksSchema schema = new StarRocksSchema(fields);
+
+        Map<String, String> options = new HashMap<>();
+        options.put(StarRocksConfigBase.KEY_COLUMN_TYPES,
+                "`identifier` STRUCT<`type`: STRING, `id`: STRING>");
+        SimpleStarRocksConfig config = new SimpleStarRocksConfig(options);
+
+        StructType result = InferSchema.inferSchema(schema, config);
+
+        Assert.assertEquals("nested identifier", result.apply("identifier").metadata().getString("comment"));
+    }
+
+    @Test
     public void testStructOverrideApplied() {
         List<StarRocksField> fields = Arrays.asList(
                 new StarRocksField("purpose_id", "varchar", 0, null, null, null),


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #159 

## Problem Summary(Required) ：
When using the Spark Catalog to access StarRocks tables, `DESC` and `SHOW CREATE TABLE` do not display column comments, even when those comments are defined in StarRocks.

The connector currently reads only basic column metadata (`COLUMN_NAME`, `COLUMN_TYPE`, etc.) from `information_schema.COLUMNS` and does not fetch `COLUMN_COMMENT` or propagate it into Spark `StructField` metadata.

This PR adds column comment support for Catalog mode by:
1. Including `COLUMN_COMMENT` in the schema query in `StarRocksConnector`
2. Storing the comment on `StarRocksField`
3. Writing the comment into `StructField` metadata in `InferSchema`

After this change, column comments are visible in `DESC catalog.db.table` and `SHOW CREATE TABLE catalog.db.table`.

Note: table-level comments are out of scope for this PR.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function