### PR TITLE
Fix automatic inference for nested column types

### DIFF
--- a/docs/connector-read.md
+++ b/docs/connector-read.md
@@ -217,11 +217,11 @@ The following parameters apply only to the Spark RDD reading method.
 | DATE                | DataTypes.DateType        |
 | DATETIME            | DataTypes.TimestampType   |
 | JSON                | DataTypes.StringType <br> **NOTE:** <br> **Supported since version 1.1.2**, and require StarRocks at least 2.5.13, 3.0.3, 3.1 or later |
-| ARRAY               | ArrayType <br> **NOTE:** <br> **Supported since version 1.1.3**. Nested types must be declared via `starrocks.column.types`. See [Read nested columns](#read-nested-columns-struct-array-and-map). |
+| ARRAY               | ArrayType <br> **NOTE:** <br> **Supported since version 1.1.3**. Automatic nested type inference is supported since version 1.1.4. See [Read nested columns](#read-nested-columns-struct-array-and-map). |
 | HLL                 | Unsupported datatype      |
 | BITMAP              | Unsupported datatype      |
-| MAP                 | MapType <br> **NOTE:** <br> **Supported since version 1.1.3**. Nested types must be declared via `starrocks.column.types`. See [Read nested columns](#read-nested-columns-struct-array-and-map). |
-| STRUCT              | StructType <br> **NOTE:** <br> **Supported since version 1.1.3**. Nested types must be declared via `starrocks.column.types`. See [Read nested columns](#read-nested-columns-struct-array-and-map). |
+| MAP                 | MapType <br> **NOTE:** <br> **Supported since version 1.1.3**. Automatic nested type inference is supported since version 1.1.4. See [Read nested columns](#read-nested-columns-struct-array-and-map). |
+| STRUCT              | StructType <br> **NOTE:** <br> **Supported since version 1.1.3**. Automatic nested type inference is supported since version 1.1.4. See [Read nested columns](#read-nested-columns-struct-array-and-map). |
 
 ### Spark connector 1.0.0
 
@@ -935,7 +935,7 @@ In this example, the filter condition `k = 1` can hit the prefix index. Therefor
 
 **Supported since version 1.1.3.**
 
-The Spark connector supports reading StarRocks columns of type `STRUCT`, `ARRAY`, and `MAP`. Because the connector cannot automatically infer the full nested type from the StarRocks schema, you must declare the column types explicitly using the `starrocks.column.types` option for every nested column.
+The Spark connector supports reading StarRocks columns of type `STRUCT`, `ARRAY`, and `MAP`. Since version 1.1.4, the connector automatically infers nested Spark types from the complete `COLUMN_TYPE` metadata returned by StarRocks.
 
 ### How it works
 
@@ -945,9 +945,9 @@ The Spark connector supports reading StarRocks columns of type `STRUCT`, `ARRAY`
 
 Nested types can be composed arbitrarily (for example, `STRUCT<a ARRAY<INT>, b MAP<STRING, BIGINT>>`).
 
-### Type-mapping caveats inside nested types
+### Override inferred types
 
-Logical StarRocks types that share an Arrow wire representation (notably `DATE`, `DATETIME`, and some `DECIMAL` encodings) are decoded correctly only when the declared type is provided via `starrocks.column.types`. Without it, those fields fall back to plain `STRING`.
+The `starrocks.column.types` option still takes precedence over automatic inference. Use it when an older StarRocks version does not return complete nested `COLUMN_TYPE` metadata, or when you need to override the default type mapping.
 
 ### Example
 
@@ -967,17 +967,11 @@ DISTRIBUTED BY HASH(id) BUCKETS 4;
 Read the table with Spark:
 
 ```scala
-val columnTypes =
-  "info STRUCT<type STRING, phone BIGINT, created TIMESTAMP>, " +
-  "tags ARRAY<STRING>, " +
-  "metadata MAP<STRING, STRUCT<value STRING, count INT>>"
-
 val df = spark.read.format("starrocks")
   .option("starrocks.fenodes", "127.0.0.1:8030")
   .option("starrocks.table.identifier", "test.nested_tbl")
   .option("starrocks.user", "root")
   .option("starrocks.password", "")
-  .option("starrocks.column.types", columnTypes)
   .load()
 
 df.printSchema()
@@ -988,7 +982,13 @@ df.printSchema()
 //  |-- metadata: map<string, struct<value: string, count: integer>>
 ```
 
-### Current limitations
+For example, you can override only the `info` column while allowing the connector to infer the other columns:
 
-- Nested type inference is **not** automatic. You must supply `starrocks.column.types` for every nested column.
-- `DATE` and `DATETIME` fields inside nested types are returned as Spark `DateType` / `TimestampType` only when the declared type is provided. Without the declaration they fall back to `StringType`.
+```scala
+.option("starrocks.column.types", "info STRUCT<type STRING, phone BIGINT, created TIMESTAMP>")
+```
+
+### Compatibility
+
+- Automatic inference requires complete `COLUMN_TYPE` metadata, such as `ARRAY<BIGINT>` rather than only `ARRAY`.
+- If complete metadata is unavailable or a nested child type is unsupported, configure that column with `starrocks.column.types`.

--- a/src/main/java/com/starrocks/connector/spark/sql/schema/InferSchema.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/schema/InferSchema.java
@@ -121,6 +121,20 @@ public final class InferSchema {
             throw new UnsupportedOperationException(
                     String.format("Unknown starrocks type for column name: %s", field.getName()));
         }
+        String normalizedRawType = rawType.trim().toLowerCase(Locale.ROOT);
+        if (normalizedRawType.startsWith("array<")
+                || normalizedRawType.startsWith("map<")
+                || normalizedRawType.startsWith("struct<")) {
+            try {
+                return StarRocksTypeParser.parse(rawType);
+            } catch (UnsupportedOperationException e) {
+                throw new UnsupportedOperationException(
+                        String.format(
+                                "Unsupported starrocks type, column name: %s, "
+                                        + "data type: %s",
+                                field.getName(), field.getType()), e);
+            }
+        }
         // Remove only the (n) or (n,m) from types like 'decimal(20,1)' or 'bigint(20) unsigned' to get 'decimal' or 'bigint unsigned'
         String type = rawType.replaceAll("\\(.*?\\)", "").toLowerCase(Locale.ROOT);
 

--- a/src/main/java/com/starrocks/connector/spark/sql/schema/StarRocksTypeParser.java
+++ b/src/main/java/com/starrocks/connector/spark/sql/schema/StarRocksTypeParser.java
@@ -1,0 +1,267 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.connector.spark.sql.schema;
+
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Parses the recursive type syntax returned by
+ * information_schema.COLUMNS.COLUMN_TYPE.
+ */
+final class StarRocksTypeParser {
+
+    /** Type text being parsed. */
+    private final String input;
+    /** Current offset in {@link #input}. */
+    private int position;
+
+    private StarRocksTypeParser(final String source) {
+        this.input = source;
+    }
+
+    static DataType parse(final String source) {
+        StarRocksTypeParser parser = new StarRocksTypeParser(source);
+        DataType dataType = parser.parseType();
+        parser.skipWhitespace();
+        if (!parser.isAtEnd()) {
+            throw parser.parseError("Unexpected trailing content");
+        }
+        return dataType;
+    }
+
+    private DataType parseType() {
+        skipWhitespace();
+        String typeName = readIdentifier().toLowerCase(Locale.ROOT);
+        switch (typeName) {
+            case "array":
+                expect('<');
+                DataType elementType = parseType();
+                expect('>');
+                return DataTypes.createArrayType(elementType, true);
+            case "map":
+                expect('<');
+                DataType keyType = parseType();
+                expect(',');
+                DataType valueType = parseType();
+                expect('>');
+                return DataTypes.createMapType(keyType, valueType, true);
+            case "struct":
+                return parseStructType();
+            default:
+                return parseScalarType(typeName);
+        }
+    }
+
+    private DataType parseStructType() {
+        expect('<');
+        List<StructField> fields = new ArrayList<>();
+        skipWhitespace();
+        if (consumeIf('>')) {
+            return DataTypes.createStructType(fields);
+        }
+
+        while (true) {
+            String fieldName = readFieldName();
+            skipWhitespace();
+            consumeIf(':');
+            DataType fieldType = parseType();
+            fields.add(new StructField(
+                    fieldName, fieldType, true, Metadata.empty()));
+            skipWhitespace();
+            if (consumeIf('>')) {
+                return DataTypes.createStructType(fields);
+            }
+            expect(',');
+        }
+    }
+
+    private DataType parseScalarType(final String typeName) {
+        List<Integer> parameters = parseIntegerParameters();
+        skipWhitespace();
+        boolean unsigned = consumeKeyword("unsigned");
+        if (unsigned && !"bigint".equals(typeName)) {
+            throw parseError("Unsigned modifier is only supported for bigint");
+        }
+
+        switch (typeName) {
+            case "boolean":
+                return DataTypes.BooleanType;
+            case "tinyint":
+                return DataTypes.ByteType;
+            case "smallint":
+                return DataTypes.ShortType;
+            case "int":
+            case "integer":
+                return DataTypes.IntegerType;
+            case "bigint":
+                return unsigned ? DataTypes.StringType : DataTypes.LongType;
+            case "largeint":
+                return DataTypes.StringType;
+            case "float":
+                return DataTypes.FloatType;
+            case "double":
+                return DataTypes.DoubleType;
+            case "decimal":
+            case "decimalv2":
+            case "decimal32":
+            case "decimal64":
+            case "decimal128":
+                if (parameters.size() != 2) {
+                    throw parseError(
+                            "Decimal type must contain precision and scale");
+                }
+                return DataTypes.createDecimalType(
+                        parameters.get(0), parameters.get(1));
+            case "char":
+            case "varchar":
+            case "string":
+            case "json":
+                return DataTypes.StringType;
+            case "date":
+                return DataTypes.DateType;
+            case "datetime":
+                return DataTypes.TimestampType;
+            default:
+                throw parseError("Unsupported type " + typeName);
+        }
+    }
+
+    private List<Integer> parseIntegerParameters() {
+        List<Integer> parameters = new ArrayList<>();
+        skipWhitespace();
+        if (!consumeIf('(')) {
+            return parameters;
+        }
+
+        parameters.add(readInteger());
+        skipWhitespace();
+        if (consumeIf(',')) {
+            parameters.add(readInteger());
+        }
+        expect(')');
+        return parameters;
+    }
+
+    private int readInteger() {
+        skipWhitespace();
+        int start = position;
+        while (!isAtEnd() && Character.isDigit(input.charAt(position))) {
+            position++;
+        }
+        if (start == position) {
+            throw parseError("Expected integer");
+        }
+        return Integer.parseInt(input.substring(start, position));
+    }
+
+    private String readFieldName() {
+        skipWhitespace();
+        if (!isAtEnd() && input.charAt(position) == '`') {
+            position++;
+            StringBuilder fieldName = new StringBuilder();
+            while (!isAtEnd()) {
+                char current = input.charAt(position++);
+                if (current != '`') {
+                    fieldName.append(current);
+                } else if (!isAtEnd() && input.charAt(position) == '`') {
+                    fieldName.append('`');
+                    position++;
+                } else {
+                    return fieldName.toString();
+                }
+            }
+            throw parseError("Unterminated quoted field name");
+        }
+        return readIdentifier();
+    }
+
+    private String readIdentifier() {
+        skipWhitespace();
+        int start = position;
+        while (!isAtEnd()) {
+            char current = input.charAt(position);
+            if (!Character.isLetterOrDigit(current) && current != '_') {
+                break;
+            }
+            position++;
+        }
+        if (start == position) {
+            throw parseError("Expected identifier");
+        }
+        return input.substring(start, position);
+    }
+
+    private boolean consumeKeyword(final String keyword) {
+        skipWhitespace();
+        int end = position + keyword.length();
+        if (end > input.length()
+                || !input.regionMatches(
+                        true, position, keyword, 0, keyword.length())) {
+            return false;
+        }
+        if (end < input.length()) {
+            char next = input.charAt(end);
+            if (Character.isLetterOrDigit(next) || next == '_') {
+                return false;
+            }
+        }
+        position = end;
+        return true;
+    }
+
+    private boolean consumeIf(final char expected) {
+        skipWhitespace();
+        if (!isAtEnd() && input.charAt(position) == expected) {
+            position++;
+            return true;
+        }
+        return false;
+    }
+
+    private void expect(final char expected) {
+        if (!consumeIf(expected)) {
+            throw parseError("Expected '" + expected + "'");
+        }
+    }
+
+    private void skipWhitespace() {
+        while (!isAtEnd() && Character.isWhitespace(input.charAt(position))) {
+            position++;
+        }
+    }
+
+    private boolean isAtEnd() {
+        return position >= input.length();
+    }
+
+    private UnsupportedOperationException parseError(final String message) {
+        return new UnsupportedOperationException(
+                String.format(
+                        "%s at position %d in StarRocks type '%s'",
+                        message, position, input));
+    }
+}

--- a/src/test/java/com/starrocks/connector/spark/sql/schema/InferSchemaTest.java
+++ b/src/test/java/com/starrocks/connector/spark/sql/schema/InferSchemaTest.java
@@ -22,15 +22,20 @@ package com.starrocks.connector.spark.sql.schema;
 import com.starrocks.connector.spark.sql.conf.SimpleStarRocksConfig;
 import com.starrocks.connector.spark.sql.conf.StarRocksConfigBase;
 import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.DecimalType;
+import org.apache.spark.sql.types.MapType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class InferSchemaTest {
 
@@ -49,10 +54,72 @@ public class InferSchemaTest {
 
         StructType result = InferSchema.inferSchema(schema, config);
         StructField identifier = result.apply("identifier");
-        Assert.assertTrue(identifier.dataType() instanceof StructType);
+        assertTrue(identifier.dataType() instanceof StructType);
         StructType identifierType = (StructType) identifier.dataType();
-        Assert.assertEquals(DataTypes.StringType, identifierType.apply("type").dataType());
-        Assert.assertEquals(DataTypes.StringType, identifierType.apply("id").dataType());
+        assertEquals(DataTypes.StringType, identifierType.apply("type").dataType());
+        assertEquals(DataTypes.StringType, identifierType.apply("id").dataType());
+    }
+
+    @Test
+    public void testInferArrayTypeFromColumnType() {
+        assertEquals(
+                DataTypes.createArrayType(DataTypes.LongType, true),
+                inferDataType("array<bigint(20)>"));
+        assertEquals(
+                DataTypes.createArrayType(DataTypes.createArrayType(DataTypes.IntegerType, true), true),
+                inferDataType("array<array<int(11)>>"));
+        assertEquals(
+                DataTypes.createArrayType(DataTypes.BooleanType, true),
+                inferDataType("array<boolean>"));
+        assertEquals(
+                DataTypes.createArrayType(DataTypes.ByteType, true),
+                inferDataType("array<tinyint(4)>"));
+    }
+
+    @Test
+    public void testInferMapTypeFromColumnType() {
+        MapType expected = DataTypes.createMapType(
+                DataTypes.StringType,
+                DataTypes.createArrayType(new DecimalType(10, 2), true),
+                true);
+        assertEquals(expected, inferDataType("map<varchar(65533),array<DECIMAL64(10,2)>>"));
+    }
+
+    @Test
+    public void testInferStructTypeFromColumnType() {
+        StructType expected = DataTypes.createStructType(Arrays.asList(
+                DataTypes.createStructField("a", DataTypes.IntegerType, true),
+                DataTypes.createStructField(
+                        "b", DataTypes.createArrayType(DataTypes.TimestampType, true), true),
+                DataTypes.createStructField("order id", DataTypes.LongType, true)
+        ));
+        assertEquals(
+                expected,
+                inferDataType(
+                        "struct<a int(11), b array<datetime>, `order id` bigint(20)>"));
+    }
+
+    @Test
+    public void testInferNestedComplexTypeFromColumnType() {
+        StructType valueType = DataTypes.createStructType(Arrays.asList(
+                DataTypes.createStructField("flag", DataTypes.BooleanType, true),
+                DataTypes.createStructField("amount", new DecimalType(20, 3), true)
+        ));
+        MapType mapType = DataTypes.createMapType(DataTypes.StringType, valueType, true);
+        assertEquals(
+                DataTypes.createArrayType(mapType, true),
+                inferDataType("array<map<string,struct<flag boolean,amount decimal128(20,3)>>>"));
+    }
+
+    @Test
+    public void testIncompleteOrInvalidComplexTypeIsUnsupported() {
+        assertThrows(UnsupportedOperationException.class, () -> inferDataType("array"));
+        assertThrows(UnsupportedOperationException.class, () -> inferDataType("array<bigint(20)"));
+        assertThrows(UnsupportedOperationException.class, () -> inferDataType("map<string>"));
+        assertThrows(UnsupportedOperationException.class, () -> inferDataType("array<int(11) unsigned>"));
+    }
+
+    private static org.apache.spark.sql.types.DataType inferDataType(String type) {
+        return InferSchema.inferDataType(new StarRocksField("c1", type, 0, null, null, null));
     }
 }
-


### PR DESCRIPTION
## What changed

- Parse recursive StarRocks `COLUMN_TYPE` metadata for `ARRAY`, `MAP`, and `STRUCT` columns.
- Preserve `starrocks.column.types` as the highest-priority per-column override.
- Add coverage for nested combinations, parameterized scalar types, quoted struct fields, and malformed metadata.
- Update the read documentation to describe automatic inference and the compatibility fallback.

## Root cause

The connector already queries `information_schema.COLUMNS.COLUMN_TYPE`, so StarRocks returns complete metadata such as `array<bigint(20)>`. However, `InferSchema` only mapped scalar type strings. As a result, reading an ARRAY column without `starrocks.column.types` failed with `Unsupported starrocks type` before a scan was planned.

## Compatibility

The new parser is used only when `COLUMN_TYPE` starts with `array<`, `map<`, or `struct<`. Existing scalar inference is unchanged. Explicit `starrocks.column.types` declarations still take precedence, which keeps the existing workaround available for older servers or incomplete metadata.
