### PR TITLE
[Enhancement] Use central-publishing-maven-plugin for deploy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -616,12 +616,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
                         <goals>
-                            <goal>jar-no-fork</goal>
+                            <goal>jar</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -629,7 +629,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -640,14 +640,39 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.5.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>oss</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <phase>clean</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.8.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>published</waitUntil>
                 </configuration>
             </plugin>
             <plugin>
@@ -681,29 +706,6 @@
         </plugins>
     </build>
 
-    <repositories>
-        <repository>
-            <id>oss.sonatype.org-snapshot</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
-    <distributionManagement>
-         <snapshotRepository>
-             <id>ossrh</id>
-             <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-         </snapshotRepository>
-         <repository>
-             <id>ossrh</id>
-             <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-         </repository>
-     </distributionManagement>
      <reporting>
          <plugins>
              <plugin>


### PR DESCRIPTION
## What type of PR is this：

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：

N/A

## Problem Summary(Required) ：

Migrate Maven publishing from the legacy OSSRH Nexus staging service to the Sonatype Central Publisher Portal, following the approach used by the Flink connector.

- Replace `nexus-staging-maven-plugin` with `central-publishing-maven-plugin`.
- Enable automatic publishing and wait until the deployment is published.
- Add `flatten-maven-plugin` so profile-derived Spark/Scala artifact coordinates are resolved in the published POM.
- Update the source and Javadoc plugins required for the Central bundle.
- Remove obsolete OSSRH repositories and `distributionManagement`.

No real artifact deployment was performed.

## Verification

- `JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 bash build.sh 3.3`
- Verified the Spark 3.3 primary, sources, and Javadoc JARs and the flattened `3.3_2.12` coordinates.
- Generated and checked effective POMs for Spark 3.3/JDK8 and Spark 4.0/JDK17.
- Confirmed both profiles contain the Central configuration and no legacy OSSRH configuration.
- Full local Spark 4.0 packaging was blocked before compilation by a sandbox-created Maven cache ownership issue; the PR CI matrix covers Spark 3.3/3.4/3.5 with JDK8 and Spark 4.0 with JDK17.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
