### PR TITLE
[Enhancement] Migrate to Central Publisher Portal and support Spark 4.1

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
-      max-parallel: 4
+      max-parallel: 5
       matrix:
         include:
           - spark: '3.3'
@@ -47,6 +47,8 @@ jobs:
           - spark: '3.5'
             java: '8'
           - spark: '4.0'
+            java: '17'
+          - spark: '4.1'
             java: '17'
     env:
       CUSTOM_MVN: mvn -B -ntp

--- a/common.sh
+++ b/common.sh
@@ -31,7 +31,7 @@ if ! ${MVN_CMD} --version; then
 fi
 export MVN_CMD
 
-SUPPORTED_SPARK_VERSIONS=("3.3" "3.4" "3.5" "4.0")
+SUPPORTED_SPARK_VERSIONS=("3.3" "3.4" "3.5" "4.0" "4.1")
 VERSION_MESSAGE=$(IFS=, ; echo "${SUPPORTED_SPARK_VERSIONS[*]}")
 
 function check_spark_version_supported() {

--- a/deploy.sh
+++ b/deploy.sh
@@ -31,7 +31,7 @@ fi
 spark_version=$1
 check_spark_version_supported $spark_version
 
-${MVN_CMD} clean deploy -DskipTests -Pspark-${spark_version}
+${MVN_CMD} clean deploy -Prelease -DskipTests -Pspark-${spark_version}
 
 echo "*********************************************************************"
 echo "Successfully deploy Spark StarRocks Connector for Spark $spark_version"

--- a/pom.xml
+++ b/pom.xml
@@ -616,12 +616,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
                         <goals>
-                            <goal>jar-no-fork</goal>
+                            <goal>jar</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -640,14 +640,39 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.5.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>oss</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <phase>clean</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.8.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>published</waitUntil>
                 </configuration>
             </plugin>
             <plugin>
@@ -681,30 +706,7 @@
         </plugins>
     </build>
 
-    <repositories>
-        <repository>
-            <id>oss.sonatype.org-snapshot</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
-    <distributionManagement>
-         <snapshotRepository>
-             <id>ossrh</id>
-             <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-         </snapshotRepository>
-         <repository>
-             <id>ossrh</id>
-             <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-         </repository>
-     </distributionManagement>
-     <reporting>
+    <reporting>
          <plugins>
              <plugin>
                  <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         <arrow.version>5.0.0</arrow.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <fasterxml.version>2.12.0</fasterxml.version>
+        <fasterxml.annotations.version>${fasterxml.version}</fasterxml.annotations.version>
         <slf4j.version>1.7.32</slf4j.version>
         <log4j.version>2.17.2</log4j.version>
         <httpclient.version>4.5.13</httpclient.version>
@@ -266,6 +267,43 @@
 
         </profile>
 
+        <profile>
+            <id>spark-4.1</id>
+            <activation>
+                <property>
+                    <name>env.spark-4.1</name>
+                </property>
+            </activation>
+
+            <properties>
+                <env.STARROCKS_SCALA_VERSION>2.13</env.STARROCKS_SCALA_VERSION>
+                <env.STARROCKS_SPARK_VERSION>4.1.0</env.STARROCKS_SPARK_VERSION>
+                <env.SPARK_FEATURE_VERSION>4.1</env.SPARK_FEATURE_VERSION>
+                <scala-lang.version>2.13.17</scala-lang.version>
+                <fasterxml.version>2.20.0</fasterxml.version>
+                <fasterxml.annotations.version>2.20</fasterxml.annotations.version>
+                <slf4j.version>2.0.17</slf4j.version>
+                <log4j.version>2.24.3</log4j.version>
+                <java.source.version>17</java.source.version>
+                <java.target.version>17</java.target.version>
+                <scala-maven-plugin.version>4.9.5</scala-maven-plugin.version>
+                <mockito-scala.version>1.17.37</mockito-scala.version>
+                <commons-lang3.version>3.19.0</commons-lang3.version>
+                <arrow.version>18.3.0</arrow.version>
+                <surefire.argLine>--add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED</surefire.argLine>
+            </properties>
+
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j2-impl</artifactId>
+                    <version>${log4j.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+
+        </profile>
+
     </profiles>
 
     <dependencies>
@@ -345,7 +383,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${fasterxml.version}</version>
+            <version>${fasterxml.annotations.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <fasterxml.annotations.version>${fasterxml.version}</fasterxml.annotations.version>
         <slf4j.version>1.7.32</slf4j.version>
         <log4j.version>2.17.2</log4j.version>
+        <netty.version>4.1.87.Final</netty.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.15</httpcore.version>
         <fastjson.version>1.2.83</fastjson.version>
@@ -284,6 +285,9 @@
                 <fasterxml.annotations.version>2.20</fasterxml.annotations.version>
                 <slf4j.version>2.0.17</slf4j.version>
                 <log4j.version>2.24.3</log4j.version>
+                <netty.version>4.2.7.Final</netty.version>
+                <httpclient.version>4.5.14</httpclient.version>
+                <httpcore.version>4.4.16</httpcore.version>
                 <java.source.version>17</java.source.version>
                 <java.target.version>17</java.target.version>
                 <scala-maven-plugin.version>4.9.5</scala-maven-plugin.version>
@@ -316,7 +320,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.87.Final</version>
+            <version>${netty.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -308,6 +308,39 @@
 
         </profile>
 
+        <profile>
+            <id>release</id>
+            <activation>
+                <property>
+                    <name>release</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
     </profiles>
 
     <dependencies>
@@ -716,20 +749,6 @@
                     <autoPublish>true</autoPublish>
                     <waitUntil>published</waitUntil>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：

N/A

## Problem Summary(Required) ：

Sonatype retired the legacy OSSRH service, so the connector's `s01.oss.sonatype.org` deployment configuration can no longer be used for releases. The connector also needs a build target for Apache Spark 4.1.0.

This PR migrates publishing to the Central Publisher Portal, following the StarRocks Flink connector's publishing behavior:

- adds `flatten-maven-plugin` 1.5.0 so profile-derived Spark/Scala artifact coordinates are resolved in the published POM;
- adds `central-publishing-maven-plugin` 0.8.0 with server ID `central`, automatic publishing, and waiting until publication completes;
- upgrades `maven-source-plugin` to 3.2.1 and uses the `jar` goal;
- removes the legacy Nexus staging plugin, s01 snapshot repository, and distribution management configuration.

The Spark connector keeps `maven-javadoc-plugin` 2.9.1. Version 3.3.1 does not include this mixed Java/Scala project's compiled Scala classes in the main Javadoc classpath under JDK 17, which produces an empty Javadoc JAR.

This PR also adds Spark 4.1.0 support:

- adds an independent `spark-4.1` profile using Scala 2.13.17 and JDK 17;
- produces `starrocks-spark-connector-4.1_2.13`;
- aligns Jackson, Netty, Apache HttpComponents, SLF4J, Log4j, Arrow, and other profile dependencies with Spark 4.1.0 while preserving existing profile defaults;
- accepts `build.sh 4.1` and adds Spark 4.1 / JDK 17 to the CI matrix.

Validation:

- built Spark 4.1 with JDK 17 through `build.sh 4.1`;
- passed 16 Docker-independent Spark 4.1 unit tests;
- verified Spark 4.1's effective and flattened POMs contain concrete coordinates and aligned dependency versions;
- verified Spark 4.0 retains its previous Netty and Apache HttpComponents versions;
- verified the main, sources, and non-empty Javadoc JARs, including ZIP integrity.
- PR CI passes all five Spark matrix entries: 3.3, 3.4, 3.5, 4.0, and 4.1.

No real deployment was performed. The local integration-test suite cannot access the Docker socket, so PR CI is responsible for the Docker-backed integration tests for all Spark matrix entries.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
