### PR TITLE
[Tool] Add Spark connector release skill

### DIFF
--- a/.claude/skills/spark-connector-release/SKILL.md
+++ b/.claude/skills/spark-connector-release/SKILL.md
@@ -23,8 +23,8 @@ artifacts after publication.
   there. `preflight.sh` enforces this.
 - Treat `common.sh` as the only source of supported Spark minor versions. A profile that
   exists only in `pom.xml` is not releasable unless `common.sh` lists it.
-- Use JDK 8 for Spark 3.x and JDK 17 for Spark 4.x. The scripts verify both the active JDK
-  and the resulting connector class-file version.
+- Use JDK 8 for Spark 3.x and JDK 17 for Spark 4.x. The scripts verify the active JDK and
+  the profile's Java source/target configuration.
 - Stop on any non-zero script result. Never bypass the verification marker or publication
   confirmation.
 - Never attempt to overwrite or redeploy coordinates already published to Maven Central.
@@ -85,7 +85,7 @@ validation checks:
 - no connector `SNAPSHOT` version;
 - embedded connector commit equals the release-tag commit;
 - Spark/Scala artifact suffixes match the selected profile;
-- connector-owned classes use Java 8 or Java 17 bytecode as required;
+- connector-owned classes are present in the shaded JAR;
 - the released Stream Load SDK version and its shaded classes/metadata are present;
 - the bundle contains the primary JAR, sources, Javadocs, POM, GPG signatures, and all
   configured checksums, and each signature/checksum verifies locally.

--- a/.claude/skills/spark-connector-release/SKILL.md
+++ b/.claude/skills/spark-connector-release/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: spark-connector-release
+description: >-
+  Release the StarRocks Spark connector to Central Publisher Portal and Maven
+  Central. Use whenever a user asks to release, publish, deploy, tag, verify, or
+  create GitHub release artifacts for starrocks-connector-for-apache-spark, including
+  requests mentioning deploy.sh, Spark-version artifacts, Central Portal, Maven
+  coordinates, GPG signing, release candidates, or connector version bumps. This
+  skill protects the irreversible publication with per-Spark JDK selection, local
+  artifact verification, explicit confirmation, and post-publication verification.
+---
+
+# Release the StarRocks Spark Connector
+
+Maven Central releases are immutable. Build and verify every intended Spark artifact
+from the exact release tag before publishing anything, then verify the downloaded
+artifacts after publication.
+
+## Non-negotiable rules
+
+- Run the release in a primary Git checkout. Do not create or use a linked worktree for
+  the release build: this repository's Git metadata plugin omits the connector fingerprint
+  there. `preflight.sh` enforces this.
+- Treat `common.sh` as the only source of supported Spark minor versions. A profile that
+  exists only in `pom.xml` is not releasable unless `common.sh` lists it.
+- Use JDK 8 for Spark 3.x and JDK 17 for Spark 4.x. The scripts verify both the active JDK
+  and the resulting connector class-file version.
+- Stop on any non-zero script result. Never bypass the verification marker or publication
+  confirmation.
+- Never attempt to overwrite or redeploy coordinates already published to Maven Central.
+  If one version fails after others succeed, inspect Central Portal and retry only the
+  unpublished version.
+- Create a draft GitHub release only. A maintainer reviews and publishes the draft.
+
+For prerequisites and troubleshooting, read
+[`references/release-guide.md`](references/release-guide.md).
+
+## Release workflow
+
+Run all commands from the repository root. The scripts locate the repository through Git;
+`CONNECTOR_REPO=/absolute/path` is also supported.
+
+```bash
+SKILL=.claude/skills/spark-connector-release
+
+$SKILL/scripts/preflight.sh
+$SKILL/scripts/prepare_release.sh 1.2.0
+$SKILL/scripts/build_verify.sh
+git push origin v1.2.0
+$SKILL/scripts/publish.sh
+$SKILL/scripts/verify_central.sh 1.2.0
+$SKILL/scripts/create_github_release.sh RELEASE_NOTES.md
+```
+
+### Check the release machine
+
+`preflight.sh` is read-only. It checks the primary-checkout requirement, clean tree,
+repository identity, commands, supported Spark profiles, Scala/JDK mappings, both JDK
+installations, released Stream Load SDK dependency, Central credentials, GPG key, signing
+configuration, and GitHub authentication.
+
+Prefer `JAVA8_HOME` and `JAVA17_HOME`. When unset, the scripts inspect the active Java,
+standard JVM installation directories, and `update-alternatives`. They abort unless the
+discovered runtime reports the exact required major version.
+
+### Prepare the release commit and local tag
+
+`prepare_release.sh <version>` fetches `origin/main`, creates `release-<version>`, sets
+the top-level Maven version, commits it, and creates local tag `v<version>`. It refuses to
+reuse a local or remote branch/tag and does not push anything.
+
+### Build and verify without publishing
+
+`build_verify.sh [spark-minor ...]` invokes the repository's `deploy.sh` with Central
+plugin property `skipPublishing=true` and the JDK required by each selected Spark profile.
+This exercises the actual release profiles, GPG signing, sources/Javadocs generation, and
+Central bundle construction without uploading anything. With no arguments it covers every
+version from `common.sh`.
+
+Because each dry run starts with `mvn clean`, the script copies every verified primary JAR
+and signed Central bundle to local release state under the repository's Git directory. The
+validation checks:
+
+- exact filename and Maven `groupId`, `artifactId`, and release version;
+- no connector `SNAPSHOT` version;
+- embedded connector commit equals the release-tag commit;
+- Spark/Scala artifact suffixes match the selected profile;
+- connector-owned classes use Java 8 or Java 17 bytecode as required;
+- the released Stream Load SDK version and its shaded classes/metadata are present;
+- the bundle contains the primary JAR, sources, Javadocs, POM, GPG signatures, and all
+  configured checksums, and each signature/checksum verifies locally.
+
+The stage records SHA-256 checksums and per-version verification metadata. Push the tag
+only after all intended versions pass.
+
+### Publish through Central Portal
+
+`publish.sh [spark-minor ...]` is the irreversible step. It requires:
+
+- `HEAD`, local tag, and origin tag to resolve to the same commit;
+- a clean checkout and matching verification state;
+- intact staged JARs and signed Central bundles for every requested Spark version;
+- coordinates that do not already exist on Maven Central;
+- the user to type the release version, or explicitly provide
+  `CONFIRM_PUBLISH=<version>` for a non-interactive run.
+
+It switches JDK for each profile and invokes the repository's existing `deploy.sh` without
+the dry-run flag. The POM activates the `release` and selected Spark profiles together.
+Publication stops at the first failure.
+
+### Verify Maven Central
+
+`verify_central.sh <version> [spark-minor ...]` downloads each published POM, primary
+JAR, sources, Javadocs, and signature from Maven Central, verifies every GPG signature,
+and runs the strict JAR verifier against the public bytes. It retains the verified primary
+JARs and their SHA-256 values for the GitHub release.
+
+### Prepare release notes and create the draft
+
+Copy [`assets/release-note-template.md`](assets/release-note-template.md) and fill it from
+all merged PRs between the previous release tag and the new tag. Classify each PR by its
+subject prefix:
+
+- `[Feature]` → Features
+- `[Enhancement]` → Enhancements
+- `[BugFix]` → BugFix
+- `[Doc]` → Doc
+- `[Tool]`, `[Chore]`, build, CI, release, or skill changes → Tool
+- anything else → Other
+
+Exclude only the release/version-bump commit itself. Before creating the draft, show the
+user every included/excluded PR and its proposed group, then wait for explicit confirmation.
+
+`create_github_release.sh <notes-file>` requires every `common.sh` version to have passed
+public Central verification. It uploads those downloaded JARs to a draft release on
+`StarRocks/starrocks-connector-for-apache-spark`; it never publishes the draft.
+
+## Re-running after a failure
+
+The build, publish, and Central-verification scripts accept Spark minor versions. For
+example:
+
+```bash
+$SKILL/scripts/build_verify.sh 4.1
+$SKILL/scripts/publish.sh 4.1
+$SKILL/scripts/verify_central.sh 1.2.0 4.1
+```
+
+Use a subset only when recovering a failed or unpublished version. Local state records
+successful publication and refuses to publish the same version twice. If execution was
+interrupted during upload, check the Central Portal deployment before retrying; absence
+from the public Maven mirror alone does not prove that an upload never happened.

--- a/.claude/skills/spark-connector-release/SKILL.md
+++ b/.claude/skills/spark-connector-release/SKILL.md
@@ -104,9 +104,10 @@ only after all intended versions pass.
 - the user to type the release version, or explicitly provide
   `CONFIRM_PUBLISH=<version>` for a non-interactive run.
 
-It switches JDK for each profile and invokes the repository's existing `deploy.sh` without
-the dry-run flag. The POM activates the `release` and selected Spark profiles together.
-Publication stops at the first failure.
+It uploads each already-verified signed bundle directly to the Central Publisher API with
+automatic publishing; it does not rebuild the artifact. The in-flight marker records the
+bundle SHA-256 and returned Central deployment ID before polling that deployment to
+`PUBLISHED`. Publication stops at the first failure.
 
 ### Verify Maven Central
 
@@ -148,5 +149,6 @@ $SKILL/scripts/verify_central.sh 1.2.0 4.1
 
 Use a subset only when recovering a failed or unpublished version. Local state records
 successful publication and refuses to publish the same version twice. If execution was
-interrupted during upload, check the Central Portal deployment before retrying; absence
-from the public Maven mirror alone does not prove that an upload never happened.
+interrupted during upload, use the deployment ID in `publishing-<spark>.env` to check the
+Central Portal before retrying; absence from the public Maven mirror alone does not prove
+that an upload never happened.

--- a/.claude/skills/spark-connector-release/assets/release-note-template.md
+++ b/.claude/skills/spark-connector-release/assets/release-note-template.md
@@ -1,0 +1,29 @@
+## What's Changed
+
+**Features**
+
+- <short description>. [#<PR>](https://github.com/StarRocks/starrocks-connector-for-apache-spark/pull/<PR>)
+
+**Enhancements**
+
+- <short description>. [#<PR>](https://github.com/StarRocks/starrocks-connector-for-apache-spark/pull/<PR>)
+
+**BugFix**
+
+- <short description>. [#<PR>](https://github.com/StarRocks/starrocks-connector-for-apache-spark/pull/<PR>)
+
+**Doc**
+
+- <short description>. [#<PR>](https://github.com/StarRocks/starrocks-connector-for-apache-spark/pull/<PR>)
+
+**Tool**
+
+- <short description>. [#<PR>](https://github.com/StarRocks/starrocks-connector-for-apache-spark/pull/<PR>)
+
+**Other**
+
+- <short description>. [#<PR>](https://github.com/StarRocks/starrocks-connector-for-apache-spark/pull/<PR>)
+
+## Contributors
+
+[<handle>](https://github.com/<handle>), [<handle>](https://github.com/<handle>)

--- a/.claude/skills/spark-connector-release/references/release-guide.md
+++ b/.claude/skills/spark-connector-release/references/release-guide.md
@@ -1,0 +1,128 @@
+# StarRocks Spark Connector Release Guide
+
+This guide explains the release model and machine prerequisites. The executable workflow
+is defined in `SKILL.md` and `scripts/` one directory above.
+
+## Published artifacts
+
+Every supported Spark minor version has distinct Maven coordinates:
+
+```text
+com.starrocks:starrocks-spark-connector-<spark-minor>_<scala-binary>:<connector-version>
+```
+
+For example, connector `1.2.0` produces artifacts such as:
+
+```text
+com.starrocks:starrocks-spark-connector-3.5_2.12:1.2.0
+com.starrocks:starrocks-spark-connector-4.1_2.13:1.2.0
+```
+
+The supported minor-version list comes exclusively from `common.sh`. The Spark profiles in
+`pom.xml` provide the full Spark version, Scala binary version, and Java target.
+
+## JDK requirements
+
+The release uses the JDK matching the selected Spark generation:
+
+| Spark generation listed by `common.sh` | Scala binary | Maven runtime JDK | Connector class major |
+| --- | --- | --- | --- |
+| 3.x | 2.12 | 8 | 52 |
+| 4.x | 2.13 | 17 | 61 |
+
+Set `JAVA8_HOME` and `JAVA17_HOME` when possible. Automatic discovery is a fallback, and
+the scripts always execute `java -version` against the selected home before building or
+publishing.
+
+## Checkout requirement
+
+Use a primary checkout whose `.git` is the repository directory. The Git metadata plugin
+version in this project does not correctly generate `starrocks-spark-connector-git.properties`
+from a linked worktree. Maven can still report success in that situation, leaving a JAR that
+cannot be tied back to its release tag. The preflight rejects linked worktrees explicitly.
+
+## Central Publisher Portal credentials
+
+The POM uses `org.sonatype.central:central-publishing-maven-plugin` with server id `central`.
+Create a Central Portal user token for an account authorized to publish `com.starrocks`, and
+place it in Maven settings without committing it:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>central</id>
+      <username>TOKEN_USERNAME</username>
+      <password>TOKEN_PASSWORD</password>
+    </server>
+  </servers>
+</settings>
+```
+
+The default file is `~/.m2/settings.xml`. Set `MAVEN_SETTINGS` when using another file.
+
+## GPG signing
+
+Central requires signatures for the main artifact, POM, sources, and Javadocs. Import the
+designated release secret key and publish its public key to a public keyserver. The POM's
+`release` profile configures Maven GPG signing with loopback pinentry, allowing the passphrase
+to come from Maven settings or `gpg-agent`.
+
+Verify the key before release:
+
+```bash
+gpg --list-secret-keys --keyid-format LONG
+```
+
+Do not print credentials or passphrases in command output, logs, or release state.
+
+## Local no-publish rehearsal
+
+The build-verification stage calls the repository's `deploy.sh` with
+`skipPublishing=true`. Central plugin 0.8.0 still stages and builds
+`target/central-publishing/central-bundle.zip`, then stops before its upload call. This
+validates the same release/GPG/profile path used by publication without creating a Portal
+deployment. The scripts require exactly plugin 0.8.0 for this rehearsal; after any plugin
+upgrade, review the plugin behavior and update the guard before releasing.
+
+## Release state
+
+Local build evidence is stored beneath the repository's Git directory in
+`spark-connector-release/v<version>/`. It includes:
+
+- copied primary JARs and signed Central bundles from each local rehearsal;
+- their SHA-256 checksums;
+- tag commit and verified-version metadata;
+- publication completion markers;
+- artifacts downloaded and verified from Maven Central.
+
+Because this state is outside the tracked work tree, it cannot dirty the release tag. It is
+machine-local evidence, not a substitute for checking Central Portal after an interrupted
+publication.
+
+## Why publication is gated
+
+Maven Central coordinates are immutable. The safe order is:
+
+1. create a release commit and local tag;
+2. build all signed bundles from that exact commit without uploading;
+3. inspect the real JAR metadata, signatures, checksums, and class bytes;
+4. push the verified tag;
+5. publish with explicit confirmation;
+6. download and verify what Maven Central serves;
+7. create a draft GitHub release from the verified public JARs.
+
+## Failure recovery
+
+| Symptom | Action |
+| --- | --- |
+| A JDK cannot be found | Set `JAVA8_HOME` or `JAVA17_HOME` to the required installation. |
+| Preflight reports a linked worktree | Use a primary clone/checkout for the release. |
+| Connector Git properties are missing | Do not publish; confirm the checkout type and rebuild. |
+| Class major is wrong | Confirm the selected `JAVA_HOME`, profile Java target, and rebuild. |
+| GPG signing fails | Check the secret key, passphrase source, loopback support, and `gpg-agent`. |
+| Central authentication fails | Regenerate/check the Portal token and namespace permission. |
+| One Spark artifact publishes and the next fails | Keep the published coordinates; fix and retry only the unpublished Spark version. |
+| The public JAR returns 404 immediately | Wait for mirror synchronization and rerun public verification. |
+| Publication was interrupted | Inspect the Portal deployment before any retry. |
+| GitHub release creation fails | Published artifacts remain valid; fix authentication/notes and recreate only the draft. |

--- a/.claude/skills/spark-connector-release/references/release-guide.md
+++ b/.claude/skills/spark-connector-release/references/release-guide.md
@@ -25,10 +25,10 @@ The supported minor-version list comes exclusively from `common.sh`. The Spark p
 
 The release uses the JDK matching the selected Spark generation:
 
-| Spark generation listed by `common.sh` | Scala binary | Maven runtime JDK | Connector class major |
-| --- | --- | --- | --- |
-| 3.x | 2.12 | 8 | 52 |
-| 4.x | 2.13 | 17 | 61 |
+| Spark generation listed by `common.sh` | Scala binary | Maven runtime JDK |
+| --- | --- | --- |
+| 3.x | 2.12 | 8 |
+| 4.x | 2.13 | 17 |
 
 Set `JAVA8_HOME` and `JAVA17_HOME` when possible. Automatic discovery is a fallback, and
 the scripts always execute `java -version` against the selected home before building or
@@ -119,7 +119,6 @@ Maven Central coordinates are immutable. The safe order is:
 | A JDK cannot be found | Set `JAVA8_HOME` or `JAVA17_HOME` to the required installation. |
 | Preflight reports a linked worktree | Use a primary clone/checkout for the release. |
 | Connector Git properties are missing | Do not publish; confirm the checkout type and rebuild. |
-| Class major is wrong | Confirm the selected `JAVA_HOME`, profile Java target, and rebuild. |
 | GPG signing fails | Check the secret key, passphrase source, loopback support, and `gpg-agent`. |
 | Central authentication fails | Regenerate/check the Portal token and namespace permission. |
 | One Spark artifact publishes and the next fails | Keep the published coordinates; fix and retry only the unpublished Spark version. |

--- a/.claude/skills/spark-connector-release/references/release-guide.md
+++ b/.claude/skills/spark-connector-release/references/release-guide.md
@@ -30,9 +30,10 @@ The release uses the JDK matching the selected Spark generation:
 | 3.x | 2.12 | 8 |
 | 4.x | 2.13 | 17 |
 
-Set `JAVA8_HOME` and `JAVA17_HOME` when possible. Automatic discovery is a fallback, and
-the scripts always execute `java -version` against the selected home before building or
-publishing.
+Set `JAVA8_HOME` and `JAVA17_HOME` when possible. Automatic discovery is a fallback.
+Preflight verifies both installations, and build verification executes `java -version`
+against the selected home before each Spark build. Publication uploads those verified
+bundle bytes directly and does not launch Java.
 
 ## Checkout requirement
 
@@ -43,9 +44,10 @@ cannot be tied back to its release tag. The preflight rejects linked worktrees e
 
 ## Central Publisher Portal credentials
 
-The POM uses `org.sonatype.central:central-publishing-maven-plugin` with server id `central`.
-Create a Central Portal user token for an account authorized to publish `com.starrocks`, and
-place it in Maven settings without committing it:
+The POM uses `org.sonatype.central:central-publishing-maven-plugin` with server id `central`
+to build the signed bundle. `publish.sh` sends that verified bundle directly to the Central
+Publisher API. Create a Central Portal user token for an account authorized to publish
+`com.starrocks`, and place it in Maven settings without committing it:
 
 ```xml
 <settings>
@@ -59,7 +61,11 @@ place it in Maven settings without committing it:
 </settings>
 ```
 
-The default file is `~/.m2/settings.xml`. Set `MAVEN_SETTINGS` when using another file.
+The default file is `~/.m2/settings.xml`. Set `MAVEN_SETTINGS` when using another file. The
+API uploader can read plain token values from this entry. If the Maven password is encrypted,
+export its decrypted values as `CENTRAL_USERNAME` and `CENTRAL_PASSWORD` for the release
+process instead. The uploader keeps its authorization header in a mode-600 temporary file
+and never writes the credentials to logs or release state.
 
 ## GPG signing
 
@@ -81,9 +87,10 @@ Do not print credentials or passphrases in command output, logs, or release stat
 The build-verification stage calls the repository's `deploy.sh` with
 `skipPublishing=true`. Central plugin 0.8.0 still stages and builds
 `target/central-publishing/central-bundle.zip`, then stops before its upload call. This
-validates the same release/GPG/profile path used by publication without creating a Portal
-deployment. The scripts require exactly plugin 0.8.0 for this rehearsal; after any plugin
-upgrade, review the plugin behavior and update the guard before releasing.
+validates the release/GPG/profile path and creates the exact bundle later sent to the Portal,
+without creating a deployment during rehearsal. The scripts require exactly plugin 0.8.0
+for this behavior; after any plugin upgrade, review the plugin behavior and update the guard
+before releasing.
 
 ## Release state
 
@@ -93,7 +100,7 @@ Local build evidence is stored beneath the repository's Git directory in
 - copied primary JARs and signed Central bundles from each local rehearsal;
 - their SHA-256 checksums;
 - tag commit and verified-version metadata;
-- publication completion markers;
+- in-flight and completion markers containing the bundle SHA-256 and Central deployment ID;
 - artifacts downloaded and verified from Maven Central.
 
 Because this state is outside the tracked work tree, it cannot dirty the release tag. It is
@@ -106,9 +113,9 @@ Maven Central coordinates are immutable. The safe order is:
 
 1. create a release commit and local tag;
 2. build all signed bundles from that exact commit without uploading;
-3. inspect the real JAR metadata, signatures, checksums, and class bytes;
+3. inspect the real JAR metadata, signatures, checksums, and required shaded classes;
 4. push the verified tag;
-5. publish with explicit confirmation;
+5. upload that exact verified bundle with explicit confirmation;
 6. download and verify what Maven Central serves;
 7. create a draft GitHub release from the verified public JARs.
 
@@ -123,5 +130,5 @@ Maven Central coordinates are immutable. The safe order is:
 | Central authentication fails | Regenerate/check the Portal token and namespace permission. |
 | One Spark artifact publishes and the next fails | Keep the published coordinates; fix and retry only the unpublished Spark version. |
 | The public JAR returns 404 immediately | Wait for mirror synchronization and rerun public verification. |
-| Publication was interrupted | Inspect the Portal deployment before any retry. |
+| Publication was interrupted | Read the deployment ID from `publishing-<spark>.env` and inspect that Portal deployment before any retry. |
 | GitHub release creation fails | Published artifacts remain valid; fix authentication/notes and recreate only the draft. |

--- a/.claude/skills/spark-connector-release/scripts/build_verify.sh
+++ b/.claude/skills/spark-connector-release/scripts/build_verify.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Modifications Copyright 2021 StarRocks Limited.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib.sh"
+
+REPO_ROOT="$(resolve_repo)"
+cd "$REPO_ROOT"
+assert_primary_checkout "$REPO_ROOT"
+assert_clean_checkout "$REPO_ROOT"
+assert_central_dry_run_contract "$REPO_ROOT"
+trap 'cleanup_maven_generated_files "$REPO_ROOT"' EXIT
+
+VERSION="$(pom_connector_version "$REPO_ROOT")"
+[ -n "$VERSION" ] || die "cannot determine connector version"
+pom_is_snapshot "$REPO_ROOT" && die "pom.xml is still a SNAPSHOT; run prepare_release.sh first"
+verify_head_is_tag "$REPO_ROOT" "$VERSION"
+COMMIT="$(git rev-parse HEAD)"
+SDK_VERSION="$(stream_load_sdk_version "$REPO_ROOT")"
+MAVEN_CMD="$(release_maven_command)"
+
+mapfile -t versions < <(resolve_versions "$REPO_ROOT" "$@")
+[ "${#versions[@]}" -gt 0 ] || die "no Spark versions selected"
+
+STATE_DIR="$(release_state_dir "$REPO_ROOT" "$VERSION")"
+ARTIFACT_DIR="$STATE_DIR/artifacts"
+BUNDLE_DIR="$STATE_DIR/bundles"
+mkdir -p "$ARTIFACT_DIR" "$BUNDLE_DIR"
+if [ -f "$STATE_DIR/commit" ]; then
+  [ "$(cat "$STATE_DIR/commit")" = "$COMMIT" ] \
+    || die "release state belongs to another commit; inspect and remove $STATE_DIR before continuing"
+else
+  printf '%s\n' "$COMMIT" > "$STATE_DIR/commit"
+fi
+
+info "Building connector $VERSION at $COMMIT"
+declare -a results=()
+overall=0
+
+for spark in "${versions[@]}"; do
+  scala="$(spark_scala_binary "$REPO_ROOT" "$spark")"
+  java="$(spark_java_major "$REPO_ROOT" "$spark")"
+  filename="$(artifact_filename "$VERSION" "$spark" "$scala")"
+  source_jar="$REPO_ROOT/target/$filename"
+  staged_jar="$ARTIFACT_DIR/$filename"
+  source_bundle="$REPO_ROOT/target/central-publishing/central-bundle.zip"
+  staged_bundle="$BUNDLE_DIR/central-bundle-spark-$spark.zip"
+
+  info "Building the signed Central bundle for Spark $spark / Scala $scala / JDK $java without publishing"
+  activate_java_for_spark "$REPO_ROOT" "$spark"
+  if ! CUSTOM_MVN="$MAVEN_CMD --batch-mode --no-transfer-progress -DskipPublishing=true" \
+      bash deploy.sh "$spark"; then
+    fail "deploy.sh dry-run failed for Spark $spark"
+    results+=("Spark $spark FAIL(dry-run)")
+    overall=1
+    continue
+  fi
+  if [ ! -f "$source_jar" ]; then
+    fail "expected primary JAR not found: $source_jar"
+    results+=("Spark $spark FAIL(no-jar)")
+    overall=1
+    continue
+  fi
+  if [ ! -f "$source_bundle" ]; then
+    fail "Central plugin did not create $source_bundle"
+    results+=("Spark $spark FAIL(no-bundle)")
+    overall=1
+    continue
+  fi
+  if ! "$SCRIPT_DIR/verify_bundle.sh" \
+      "$source_bundle" "$source_jar" "$COMMIT" "$VERSION" "$spark" "$scala" "$java" "$SDK_VERSION"; then
+    results+=("Spark $spark FAIL(bundle-verify)")
+    overall=1
+    continue
+  fi
+
+  cp "$source_jar" "$staged_jar"
+  cp "$source_bundle" "$staged_bundle"
+  sha="$(sha256sum "$staged_jar" | awk '{print $1}')"
+  bundle_sha="$(sha256sum "$staged_bundle" | awk '{print $1}')"
+  {
+    printf 'commit=%s\n' "$COMMIT"
+    printf 'spark=%s\n' "$spark"
+    printf 'scala=%s\n' "$scala"
+    printf 'java=%s\n' "$java"
+    printf 'artifact=%s\n' "$filename"
+    printf 'sha256=%s\n' "$sha"
+    printf 'bundle=%s\n' "$(basename "$staged_bundle")"
+    printf 'bundle_sha256=%s\n' "$bundle_sha"
+  } > "$STATE_DIR/verified-$spark.env"
+  results+=("Spark $spark OK")
+done
+
+declare -a verified=()
+mapfile -t supported < <(supported_spark_versions "$REPO_ROOT")
+for spark in "${supported[@]}"; do
+  meta="$STATE_DIR/verified-$spark.env"
+  [ -f "$meta" ] || continue
+  meta_commit="$(sed -n 's/^commit=//p' "$meta")"
+  [ "$meta_commit" = "$COMMIT" ] || continue
+  verified+=("$spark")
+done
+
+(
+  cd "$ARTIFACT_DIR"
+  : > "$STATE_DIR/SHA256SUMS"
+  for jar in *.jar; do
+    [ -f "$jar" ] || continue
+    sha256sum "$jar" >> "$STATE_DIR/SHA256SUMS"
+  done
+)
+{
+  printf 'commit=%s\n' "$COMMIT"
+  printf 'version=%s\n' "$VERSION"
+  printf 'versions=%s\n' "${verified[*]}"
+} > "$STATE_DIR/verified.env"
+
+echo
+info "Build verification summary"
+for result in "${results[@]}"; do
+  printf '  %s\n' "$result"
+done
+
+if [ "$overall" -ne 0 ]; then
+  die "one or more selected Spark builds failed; verified versions remain: ${verified[*]:-none}"
+fi
+
+info "${C_GREEN}SELECTED VERSIONS VERIFIED${C_RESET}: ${versions[*]}"
+printf 'Verification state: %s\n' "$STATE_DIR"
+printf 'Push the tag only after every intended version is verified: git push origin v%s\n' "$VERSION"

--- a/.claude/skills/spark-connector-release/scripts/build_verify.sh
+++ b/.claude/skills/spark-connector-release/scripts/build_verify.sh
@@ -87,7 +87,7 @@ for spark in "${versions[@]}"; do
     continue
   fi
   if ! "$SCRIPT_DIR/verify_bundle.sh" \
-      "$source_bundle" "$source_jar" "$COMMIT" "$VERSION" "$spark" "$scala" "$java" "$SDK_VERSION"; then
+      "$source_bundle" "$source_jar" "$COMMIT" "$VERSION" "$spark" "$scala" "$SDK_VERSION"; then
     results+=("Spark $spark FAIL(bundle-verify)")
     overall=1
     continue

--- a/.claude/skills/spark-connector-release/scripts/create_github_release.sh
+++ b/.claude/skills/spark-connector-release/scripts/create_github_release.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Modifications Copyright 2021 StarRocks Limited.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib.sh"
+
+NOTES=
+YES="${CONFIRM_DRAFT:-}"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --yes) YES=yes ;;
+    -*) die "unknown option: $1" ;;
+    *) [ -z "$NOTES" ] || die "unexpected extra argument: $1"; NOTES="$1" ;;
+  esac
+  shift
+done
+[ -n "$NOTES" ] || die "usage: create_github_release.sh <release-notes.md> [--yes]"
+[ -f "$NOTES" ] || die "release notes file not found: $NOTES"
+NOTES="$(cd "$(dirname "$NOTES")" && pwd)/$(basename "$NOTES")"
+grep -Fq "## What's Changed" "$NOTES" || die "release notes are missing the What's Changed section"
+grep -Fq '## Contributors' "$NOTES" || die "release notes are missing the Contributors section"
+
+REPO_ROOT="$(resolve_repo)"
+cd "$REPO_ROOT"
+assert_primary_checkout "$REPO_ROOT"
+require_command gh
+
+VERSION="$(pom_connector_version "$REPO_ROOT")"
+pom_is_snapshot "$REPO_ROOT" && die "pom.xml is still a SNAPSHOT"
+verify_head_is_tag "$REPO_ROOT" "$VERSION"
+COMMIT="$(git rev-parse HEAD)"
+verify_tag_on_origin "$REPO_ROOT" "$VERSION" "$COMMIT"
+TAG="v$VERSION"
+RELEASE_REPO="${RELEASE_REPO:-StarRocks/starrocks-connector-for-apache-spark}"
+STATE_DIR="$(release_state_dir "$REPO_ROOT" "$VERSION")"
+
+gh auth status >/dev/null 2>&1 || die "GitHub CLI is not authenticated"
+gh release view "$TAG" --repo "$RELEASE_REPO" >/dev/null 2>&1 \
+  && die "a GitHub release already exists for $TAG; edit or remove the existing draft instead of duplicating it"
+
+mapfile -t versions < <(supported_spark_versions "$REPO_ROOT")
+declare -a assets=()
+for spark in "${versions[@]}"; do
+  scala="$(spark_scala_binary "$REPO_ROOT" "$spark")"
+  filename="$(artifact_filename "$VERSION" "$spark" "$scala")"
+  jar="$STATE_DIR/central/$filename"
+  meta="$STATE_DIR/central-verified-$spark.env"
+  [ -f "$jar" ] && [ -f "$meta" ] \
+    || die "Spark $spark has not been verified from Maven Central; run verify_central.sh $VERSION"
+  [ "$(sed -n 's/^commit=//p' "$meta")" = "$COMMIT" ] \
+    || die "Central verification for Spark $spark belongs to another commit"
+  expected_sha="$(sed -n 's/^sha256=//p' "$meta")"
+  actual_sha="$(sha256sum "$jar" | awk '{print $1}')"
+  [ "$actual_sha" = "$expected_sha" ] || die "$filename changed after Central verification"
+  assets+=("$jar")
+done
+
+echo
+info "Will create draft GitHub release $TAG on $RELEASE_REPO"
+printf 'Notes: %s\n' "$NOTES"
+printf 'Assets:\n'
+for asset in "${assets[@]}"; do printf '  %s\n' "$(basename "$asset")"; done
+if [ -t 0 ]; then
+  printf 'Create the draft release? [y/N] '
+  read -r answer
+  [ "$answer" = y ] || [ "$answer" = Y ] || die "draft creation aborted"
+else
+  [ "$YES" = yes ] || die "non-interactive draft creation requires --yes or CONFIRM_DRAFT=yes"
+fi
+
+gh release create "$TAG" \
+  --repo "$RELEASE_REPO" \
+  --title "Release $VERSION" \
+  --notes-file "$NOTES" \
+  --draft \
+  --verify-tag \
+  "${assets[@]}"
+
+info "${C_GREEN}DRAFT GITHUB RELEASE CREATED${C_RESET}: $TAG"
+printf 'A maintainer must review and publish the draft manually.\n'

--- a/.claude/skills/spark-connector-release/scripts/lib.sh
+++ b/.claude/skills/spark-connector-release/scripts/lib.sh
@@ -338,6 +338,146 @@ central_artifact_url() {
     "$artifact" "$version" "$artifact" "$version"
 }
 
+maven_central_server_value() {
+  local settings="$1" element="$2"
+  awk -v element="$element" '
+    BEGIN { RS = "</server>"; ORS = "" }
+    /<id>[[:space:]]*central[[:space:]]*<\/id>/ {
+      opening = "<" element ">"
+      closing = "</" element ">"
+      start = index($0, opening)
+      if (start == 0) exit
+      value = substr($0, start + length(opening))
+      finish = index(value, closing)
+      if (finish == 0) exit
+      value = substr(value, 1, finish - 1)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+      print value
+      exit
+    }
+  ' "$settings"
+}
+
+write_central_curl_config() {
+  local destination="$1" settings username password authorization
+  if [ -n "${CENTRAL_USERNAME:-}" ] || [ -n "${CENTRAL_PASSWORD:-}" ]; then
+    [ -n "${CENTRAL_USERNAME:-}" ] && [ -n "${CENTRAL_PASSWORD:-}" ] \
+      || die "set both CENTRAL_USERNAME and CENTRAL_PASSWORD, or neither"
+    username="$CENTRAL_USERNAME"
+    password="$CENTRAL_PASSWORD"
+  else
+    settings="${MAVEN_SETTINGS:-${HOME}/.m2/settings.xml}"
+    [ -f "$settings" ] || die "Maven settings not found: $settings"
+    username="$(maven_central_server_value "$settings" username)"
+    password="$(maven_central_server_value "$settings" password)"
+    [ -n "$username" ] && [ -n "$password" ] \
+      || die "$settings has no complete username/password for server id central"
+    [[ "$password" != \{*\} ]] \
+      || die "the central password in $settings is Maven-encrypted; export decrypted CENTRAL_USERNAME and CENTRAL_PASSWORD for the Portal API upload"
+    [[ "$username$password" != *'&'* ]] \
+      || die "the central credentials in $settings use XML entities; export CENTRAL_USERNAME and CENTRAL_PASSWORD instead"
+  fi
+  [[ "$username$password" != *$'\n'* ]] || die "Central credentials must not contain newlines"
+  require_command base64
+  authorization="$(printf '%s:%s' "$username" "$password" | base64 | tr -d '\r\n')"
+  (umask 077; printf 'header = "Authorization: Bearer %s"\n' "$authorization" > "$destination")
+  chmod 600 "$destination"
+}
+
+upload_central_bundle() {
+  local bundle="$1" deployment_name="$2" curl_config="$3"
+  local encoded_name response http_status deployment_id
+  [ -s "$bundle" ] || die "Central bundle not found: $bundle"
+  [ -s "$curl_config" ] || die "Central API curl configuration not found: $curl_config"
+  require_command curl
+  require_command jq
+
+  encoded_name="$(jq -rn --arg value "$deployment_name" '$value | @uri')"
+  response="$(mktemp)"
+  if ! http_status="$(curl \
+      --config "$curl_config" \
+      --silent --show-error \
+      --connect-timeout 20 --max-time 600 \
+      --request POST \
+      --form "bundle=@$bundle;type=application/octet-stream" \
+      --output "$response" \
+      --write-out '%{http_code}' \
+      "https://central.sonatype.com/api/v1/publisher/upload?name=$encoded_name&publishingType=AUTOMATIC")"; then
+    rm -f "$response"
+    die "Central Portal rejected or could not receive the verified bundle"
+  fi
+  if [ "$http_status" != 201 ]; then
+    rm -f "$response"
+    die "Central Portal bundle upload returned HTTP $http_status"
+  fi
+  deployment_id="$(tr -d '\r\n' < "$response")"
+  rm -f "$response"
+  [[ "$deployment_id" =~ ^[0-9A-Fa-f-]{36}$ ]] \
+    || die "Central Portal returned an invalid deployment id"
+  printf '%s\n' "$deployment_id"
+}
+
+central_deployment_state() {
+  local deployment_id="$1" curl_config="$2" response http_status state
+  response="$(mktemp)"
+  if ! http_status="$(curl \
+      --config "$curl_config" \
+      --silent --show-error \
+      --connect-timeout 20 --max-time 60 \
+      --request POST \
+      --output "$response" \
+      --write-out '%{http_code}' \
+      "https://central.sonatype.com/api/v1/publisher/status?id=$deployment_id")"; then
+    rm -f "$response"
+    die "could not query Central Portal deployment $deployment_id"
+  fi
+  if [ "$http_status" != 200 ]; then
+    rm -f "$response"
+    die "Central Portal status query returned HTTP $http_status for deployment $deployment_id"
+  fi
+  state="$(jq -er '.deploymentState | strings' "$response" 2>/dev/null || true)"
+  rm -f "$response"
+  [ -n "$state" ] || die "Central Portal returned no state for deployment $deployment_id"
+  printf '%s\n' "$state"
+}
+
+wait_for_central_publication() {
+  local deployment_id="$1" curl_config="$2" state started now
+  started="$(date +%s)"
+  while true; do
+    state="$(central_deployment_state "$deployment_id" "$curl_config")"
+    info "Central deployment $deployment_id state: $state"
+    case "$state" in
+      PUBLISHED) return 0 ;;
+      PENDING|VALIDATING|VALIDATED|PUBLISHING) ;;
+      FAILED) die "Central deployment $deployment_id failed validation or publication; inspect Central Portal" ;;
+      *) die "Central deployment $deployment_id returned unexpected state $state" ;;
+    esac
+    now="$(date +%s)"
+    [ $((now - started)) -lt 1800 ] \
+      || die "timed out waiting for Central deployment $deployment_id; inspect Central Portal"
+    sleep 5
+  done
+}
+
+publish_verified_bundle() {
+  local bundle="$1" deployment_name="$2" curl_config="$3" in_flight_marker="$4"
+  local deployment_id bundle_sha
+  [ -f "$in_flight_marker" ] || die "publication in-flight marker not found: $in_flight_marker"
+  ! grep -q '^deployment_id=' "$in_flight_marker" \
+    || die "publication marker already contains a Central deployment id; inspect Central Portal"
+  bundle_sha="$(sha256sum "$bundle" | awk '{print $1}')"
+  if ! deployment_id="$(upload_central_bundle "$bundle" "$deployment_name" "$curl_config")"; then
+    return 1
+  fi
+  {
+    printf 'deployment_id=%s\n' "$deployment_id"
+    printf 'bundle_sha256=%s\n' "$bundle_sha"
+  } >> "$in_flight_marker"
+  pass "uploaded the verified bundle as Central deployment $deployment_id"
+  wait_for_central_publication "$deployment_id" "$curl_config"
+}
+
 property_value() {
   local key="$1"
   awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); print; exit }'

--- a/.claude/skills/spark-connector-release/scripts/lib.sh
+++ b/.claude/skills/spark-connector-release/scripts/lib.sh
@@ -1,0 +1,379 @@
+#!/usr/bin/env bash
+# Modifications Copyright 2021 StarRocks Limited.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+
+if [ -t 1 ]; then
+  C_RED=$'\033[31m'
+  C_GREEN=$'\033[32m'
+  C_YELLOW=$'\033[33m'
+  C_BLUE=$'\033[34m'
+  C_RESET=$'\033[0m'
+else
+  C_RED=
+  C_GREEN=
+  C_YELLOW=
+  C_BLUE=
+  C_RESET=
+fi
+
+info() { printf '%s==>%s %s\n' "$C_BLUE" "$C_RESET" "$*"; }
+warn() { printf '%sWARN%s %s\n' "$C_YELLOW" "$C_RESET" "$*" >&2; }
+pass() { printf '  %sPASS%s %s\n' "$C_GREEN" "$C_RESET" "$*"; }
+fail() { printf '  %sFAIL%s %s\n' "$C_RED" "$C_RESET" "$*" >&2; }
+die()  { printf '%sABORT%s %s\n' "$C_RED" "$C_RESET" "$*" >&2; exit 1; }
+
+resolve_repo() {
+  local root
+  if [ -n "${CONNECTOR_REPO:-}" ]; then
+    root="$CONNECTOR_REPO"
+  else
+    root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  fi
+  [ -n "$root" ] && [ -f "$root/pom.xml" ] && [ -f "$root/common.sh" ] \
+    || die "Cannot find the Spark connector repository; run inside it or set CONNECTOR_REPO"
+  grep -Fq '<artifactId>starrocks-spark-connector-${env.SPARK_FEATURE_VERSION}_${env.STARROCKS_SCALA_VERSION}</artifactId>' "$root/pom.xml" \
+    || die "$root is not starrocks-connector-for-apache-spark"
+  printf '%s\n' "$root"
+}
+
+pom_connector_version() {
+  awk '
+    index($0, "<artifactId>starrocks-spark-connector-${env.SPARK_FEATURE_VERSION}_${env.STARROCKS_SCALA_VERSION}</artifactId>") { found = 1; next }
+    found && /<version>[^<]+<\/version>/ {
+      line = $0
+      sub(/^.*<version>/, "", line)
+      sub(/<\/version>.*$/, "", line)
+      print line
+      exit
+    }
+  ' "$1/pom.xml"
+}
+
+pom_is_snapshot() {
+  [[ "$(pom_connector_version "$1")" == *-SNAPSHOT ]]
+}
+
+pom_root_property() {
+  local root="$1" property="$2"
+  awk -v property="$property" '
+    /<profiles>/ { exit }
+    index($0, "<" property ">") {
+      line = $0
+      sub("^.*<" property ">", "", line)
+      sub("</" property ">.*$", "", line)
+      print line
+      exit
+    }
+  ' "$root/pom.xml"
+}
+
+pom_profile_property() {
+  local root="$1" spark="$2" property="$3"
+  awk -v profile="spark-$spark" -v property="$property" '
+    index($0, "<id>" profile "</id>") { inside = 1; next }
+    inside && index($0, "<" property ">") {
+      line = $0
+      sub("^.*<" property ">", "", line)
+      sub("</" property ">.*$", "", line)
+      print line
+      exit
+    }
+    inside && /<\/profile>/ { exit }
+  ' "$root/pom.xml"
+}
+
+supported_spark_versions() {
+  local root="$1"
+  (
+    export CUSTOM_MVN=true
+    # common.sh is the sole source of the supported-version list.
+    # shellcheck disable=SC1090
+    source "$root/common.sh" >/dev/null
+    [ "${#SUPPORTED_SPARK_VERSIONS[@]}" -gt 0 ] \
+      || die "common.sh did not define SUPPORTED_SPARK_VERSIONS"
+    printf '%s\n' "${SUPPORTED_SPARK_VERSIONS[@]}"
+  )
+}
+
+resolve_versions() {
+  local root="$1"
+  shift
+  local -a supported requested
+  local candidate item found
+  declare -A supported_set=()
+  declare -A requested_set=()
+  mapfile -t supported < <(supported_spark_versions "$root")
+  [ "${#supported[@]}" -gt 0 ] || die "no supported Spark versions found in common.sh"
+  for item in "${supported[@]}"; do
+    [ -z "${supported_set[$item]:-}" ] \
+      || die "common.sh lists Spark $item more than once"
+    supported_set[$item]=1
+  done
+  if [ "$#" -eq 0 ]; then
+    printf '%s\n' "${supported[@]}"
+    return
+  fi
+  requested=("$@")
+  for candidate in "${requested[@]}"; do
+    [ -z "${requested_set[$candidate]:-}" ] \
+      || die "Spark $candidate was selected more than once"
+    requested_set[$candidate]=1
+    found=0
+    for item in "${supported[@]}"; do
+      if [ "$candidate" = "$item" ]; then
+        found=1
+        break
+      fi
+    done
+    [ "$found" -eq 1 ] || die "Spark $candidate is not supported by common.sh (supported: ${supported[*]})"
+    printf '%s\n' "$candidate"
+  done
+}
+
+spark_java_major() {
+  local root="$1" spark="$2" actual expected
+  actual="$(pom_profile_property "$root" "$spark" java.target.version)"
+  [ -n "$actual" ] || actual="$(pom_root_property "$root" java.target.version)"
+  case "$spark" in
+    3.*) expected=8 ;;
+    4.*) expected=17 ;;
+    *) die "No JDK compatibility rule is defined for Spark $spark" ;;
+  esac
+  [ "$actual" = "$expected" ] \
+    || die "Spark $spark profile targets Java $actual, expected Java $expected"
+  printf '%s\n' "$actual"
+}
+
+spark_scala_binary() {
+  local root="$1" spark="$2" actual expected
+  actual="$(pom_profile_property "$root" "$spark" env.STARROCKS_SCALA_VERSION)"
+  case "$spark" in
+    3.*) expected=2.12 ;;
+    4.*) expected=2.13 ;;
+    *) die "No Scala compatibility rule is defined for Spark $spark" ;;
+  esac
+  [ "$actual" = "$expected" ] \
+    || die "Spark $spark profile uses Scala ${actual:-<missing>}, expected $expected"
+  printf '%s\n' "$actual"
+}
+
+spark_full_version() {
+  local value
+  value="$(pom_profile_property "$1" "$2" env.STARROCKS_SPARK_VERSION)"
+  [ -n "$value" ] || die "Spark $2 profile is missing env.STARROCKS_SPARK_VERSION"
+  printf '%s\n' "$value"
+}
+
+stream_load_sdk_version() {
+  awk '
+    /<dependency>/ { inside = 1; artifact = ""; version = "" }
+    inside && /<artifactId>starrocks-stream-load-sdk<\/artifactId>/ { artifact = "yes" }
+    inside && /<version>[^<]+<\/version>/ {
+      line = $0
+      sub(/^.*<version>/, "", line)
+      sub(/<\/version>.*$/, "", line)
+      version = line
+    }
+    inside && /<\/dependency>/ {
+      if (artifact == "yes") { print version; exit }
+      inside = 0
+    }
+  ' "$1/pom.xml"
+}
+
+central_plugin_version() {
+  awk '
+    /<plugin>/ { inside = 1; central = 0 }
+    inside && /<artifactId>central-publishing-maven-plugin<\/artifactId>/ { central = 1 }
+    inside && central && /<version>[^<]+<\/version>/ {
+      line = $0
+      sub(/^.*<version>/, "", line)
+      sub(/<\/version>.*$/, "", line)
+      print line
+      exit
+    }
+    inside && /<\/plugin>/ { inside = 0 }
+  ' "$1/pom.xml"
+}
+
+assert_central_dry_run_contract() {
+  local root="$1" version
+  version="$(central_plugin_version "$root")"
+  [ "$version" = 0.8.0 ] \
+    || die "skipPublishing dry-run behavior is verified only for Central plugin 0.8.0; found ${version:-<missing>}"
+  ! grep -q 'skipPublishing' "$root/deploy.sh" \
+    || die "deploy.sh defines skipPublishing itself; review the dry-run contract before release"
+}
+
+expected_class_major() {
+  case "$1" in
+    8) printf '52\n' ;;
+    17) printf '61\n' ;;
+    *) die "No class-file mapping is defined for Java $1" ;;
+  esac
+}
+
+java_major_at_home() {
+  local home="$1" line version
+  [ -x "$home/bin/java" ] || return 1
+  line="$("$home/bin/java" -version 2>&1 | head -1)"
+  version="$(printf '%s\n' "$line" | sed -n 's/.*version "\([^"]*\)".*/\1/p')"
+  [ -n "$version" ] || return 1
+  case "$version" in
+    1.*) printf '%s\n' "$version" | cut -d. -f2 ;;
+    *) printf '%s\n' "$version" | cut -d. -f1 ;;
+  esac
+}
+
+find_java_home() {
+  local major="$1" variable configured candidate detected executable
+  local -a candidates=()
+  declare -A seen=()
+  variable="JAVA${major}_HOME"
+  configured="${!variable:-}"
+  [ -z "$configured" ] || candidates+=("$configured")
+  [ -z "${JAVA_HOME:-}" ] || candidates+=("$JAVA_HOME")
+  if command -v java >/dev/null 2>&1; then
+    executable="$(readlink -f "$(command -v java)")"
+    candidates+=("$(dirname "$(dirname "$executable")")")
+  fi
+  for candidate in /usr/lib/jvm/* /usr/java/*; do
+    [ -d "$candidate" ] && candidates+=("$candidate")
+  done
+  if command -v update-alternatives >/dev/null 2>&1; then
+    while IFS= read -r executable; do
+      [ -x "$executable" ] && candidates+=("$(dirname "$(dirname "$(readlink -f "$executable")")")")
+    done < <(update-alternatives --list java 2>/dev/null || true)
+  fi
+  for candidate in "${candidates[@]}"; do
+    [ -n "$candidate" ] || continue
+    candidate="$(readlink -f "$candidate" 2>/dev/null || true)"
+    [ -n "$candidate" ] && [ -z "${seen[$candidate]:-}" ] || continue
+    seen[$candidate]=1
+    detected="$(java_major_at_home "$candidate" 2>/dev/null || true)"
+    if [ "$detected" = "$major" ]; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+  die "JDK $major not found; set $variable to a JDK $major installation"
+}
+
+activate_java_for_spark() {
+  local root="$1" spark="$2" major home detected
+  major="$(spark_java_major "$root" "$spark")"
+  home="$(find_java_home "$major")"
+  export JAVA_HOME="$home"
+  export PATH="$JAVA_HOME/bin:$PATH"
+  detected="$(java_major_at_home "$JAVA_HOME")"
+  [ "$detected" = "$major" ] || die "Spark $spark requires JDK $major, but $JAVA_HOME reports JDK $detected"
+  pass "Spark $spark uses JDK $major ($JAVA_HOME)"
+}
+
+assert_primary_checkout() {
+  local root="$1" git_dir common_dir
+  git_dir="$(git -C "$root" rev-parse --absolute-git-dir 2>/dev/null)" \
+    || die "$root is not a Git checkout"
+  common_dir="$(git -C "$root" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" \
+    || die "cannot resolve the Git common directory"
+  [ "$git_dir" = "$common_dir" ] \
+    || die "linked Git worktree is not supported for release builds; use a primary checkout because git-commit-id-plugin 4.0.2 omits the connector fingerprint here"
+}
+
+assert_clean_checkout() {
+  [ -z "$(git -C "$1" status --porcelain)" ] \
+    || die "working tree is not clean; commit, stash, or remove local changes before continuing"
+}
+
+verify_head_is_tag() {
+  local root="$1" version="$2" tag_commit head
+  tag_commit="$(git -C "$root" rev-parse -q --verify "refs/tags/v${version}^{commit}" 2>/dev/null || true)"
+  [ -n "$tag_commit" ] || die "local tag v$version does not exist"
+  head="$(git -C "$root" rev-parse HEAD)"
+  [ "$head" = "$tag_commit" ] || die "HEAD $head is not tag v$version ($tag_commit)"
+}
+
+verify_tag_on_origin() {
+  local root="$1" version="$2" expected="$3" remote
+  remote="$(git -C "$root" ls-remote --tags origin "refs/tags/v$version" "refs/tags/v$version^{}" | tail -1 | awk '{print $1}')"
+  [ -n "$remote" ] || die "origin does not have tag v$version; push the tag only after local verification"
+  [ "$remote" = "$expected" ] || die "origin tag v$version points to $remote, expected $expected"
+}
+
+release_state_root() {
+  local root="$1" path
+  path="$(git -C "$root" rev-parse --git-path spark-connector-release)"
+  case "$path" in
+    /*) printf '%s\n' "$path" ;;
+    *) printf '%s/%s\n' "$root" "$path" ;;
+  esac
+}
+
+release_state_dir() {
+  printf '%s/v%s\n' "$(release_state_root "$1")" "$2"
+}
+
+artifact_id() {
+  printf 'starrocks-spark-connector-%s_%s\n' "$1" "$2"
+}
+
+artifact_filename() {
+  printf '%s-%s.jar\n' "$(artifact_id "$2" "$3")" "$1"
+}
+
+central_artifact_url() {
+  local version="$1" spark="$2" scala="$3" artifact
+  artifact="$(artifact_id "$spark" "$scala")"
+  printf 'https://repo.maven.apache.org/maven2/com/starrocks/%s/%s/%s-%s.jar\n' \
+    "$artifact" "$version" "$artifact" "$version"
+}
+
+property_value() {
+  local key="$1"
+  awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); print; exit }'
+}
+
+validate_release_version() {
+  [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z][0-9A-Za-z.-]*)?$ ]] \
+    || die "invalid release version '$1' (expected semantic version such as 1.2.0 or 1.2.0-RC1)"
+  [[ "$1" != *SNAPSHOT* ]] || die "release version must not contain SNAPSHOT"
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+release_maven_command() {
+  local command="${CUSTOM_MVN:-mvn}"
+  if [ -n "${MAVEN_SETTINGS:-}" ]; then
+    [[ "$MAVEN_SETTINGS" != *[[:space:]]* ]] \
+      || die "MAVEN_SETTINGS path must not contain whitespace because deploy.sh expands CUSTOM_MVN as words"
+    command="$command --settings $MAVEN_SETTINGS"
+  fi
+  printf '%s\n' "$command"
+}
+
+cleanup_maven_generated_files() {
+  # flatten-maven-plugin writes this untracked file at the repository root.
+  # A clean checkout was required before the lifecycle started, so it is safe
+  # to remove this exact generated path when a build or publication exits.
+  rm -f "$1/.flattened-pom.xml"
+}

--- a/.claude/skills/spark-connector-release/scripts/lib.sh
+++ b/.claude/skills/spark-connector-release/scripts/lib.sh
@@ -290,6 +290,22 @@ assert_primary_checkout() {
     || die "linked Git worktree is not supported for release builds; use a primary checkout because git-commit-id-plugin 4.0.2 omits the connector fingerprint here"
 }
 
+assert_official_origin() {
+  local root="$1" origin_url
+  origin_url="$(git -C "$root" remote get-url origin 2>/dev/null || true)"
+  case "$origin_url" in
+    git@github.com:StarRocks/starrocks-connector-for-apache-spark|\
+    git@github.com:StarRocks/starrocks-connector-for-apache-spark.git|\
+    https://github.com/StarRocks/starrocks-connector-for-apache-spark|\
+    https://github.com/StarRocks/starrocks-connector-for-apache-spark.git|\
+    ssh://git@github.com/StarRocks/starrocks-connector-for-apache-spark|\
+    ssh://git@github.com/StarRocks/starrocks-connector-for-apache-spark.git)
+      return
+      ;;
+  esac
+  die "origin is not the StarRocks Spark connector repository: ${origin_url:-<missing>}"
+}
+
 assert_clean_checkout() {
   [ -z "$(git -C "$1" status --porcelain)" ] \
     || die "working tree is not clean; commit, stash, or remove local changes before continuing"

--- a/.claude/skills/spark-connector-release/scripts/lib.sh
+++ b/.claude/skills/spark-connector-release/scripts/lib.sh
@@ -223,14 +223,6 @@ assert_central_dry_run_contract() {
     || die "deploy.sh defines skipPublishing itself; review the dry-run contract before release"
 }
 
-expected_class_major() {
-  case "$1" in
-    8) printf '52\n' ;;
-    17) printf '61\n' ;;
-    *) die "No class-file mapping is defined for Java $1" ;;
-  esac
-}
-
 java_major_at_home() {
   local home="$1" line version
   [ -x "$home/bin/java" ] || return 1

--- a/.claude/skills/spark-connector-release/scripts/preflight.sh
+++ b/.claude/skills/spark-connector-release/scripts/preflight.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Modifications Copyright 2021 StarRocks Limited.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib.sh"
+
+REPO_ROOT="$(resolve_repo)"
+cd "$REPO_ROOT"
+
+info "Checking Spark connector release environment"
+assert_primary_checkout "$REPO_ROOT"
+pass "repository is a primary checkout"
+assert_clean_checkout "$REPO_ROOT"
+pass "working tree is clean"
+
+for command in git mvn gpg curl unzip zip sha256sum gh; do
+  require_command "$command"
+  pass "$command is available"
+done
+
+origin_url="$(git remote get-url origin 2>/dev/null || true)"
+[[ "$origin_url" == *StarRocks/starrocks-connector-for-apache-spark* ]] \
+  || die "origin is not the StarRocks Spark connector repository: ${origin_url:-<missing>}"
+pass "origin points to StarRocks/starrocks-connector-for-apache-spark"
+
+mapfile -t versions < <(supported_spark_versions "$REPO_ROOT")
+[ "${#versions[@]}" -gt 0 ] || die "common.sh contains no supported Spark versions"
+pass "common.sh supports: ${versions[*]}"
+
+for spark in "${versions[@]}"; do
+  full="$(spark_full_version "$REPO_ROOT" "$spark")"
+  [[ "$full" == "$spark".* ]] || die "Spark $spark profile resolves full version $full"
+  scala="$(spark_scala_binary "$REPO_ROOT" "$spark")"
+  java="$(spark_java_major "$REPO_ROOT" "$spark")"
+  java_home="$(find_java_home "$java")"
+  [ "$(java_major_at_home "$java_home")" = "$java" ] \
+    || die "detected Java home $java_home does not provide JDK $java"
+  pass "Spark $spark ($full) -> Scala $scala, JDK $java ($java_home)"
+done
+
+sdk="$(stream_load_sdk_version "$REPO_ROOT")"
+[ -n "$sdk" ] || die "cannot determine starrocks-stream-load-sdk version from pom.xml"
+[[ "$sdk" != *SNAPSHOT* ]] || die "Stream Load SDK dependency must be a released version, found $sdk"
+pass "Stream Load SDK dependency is release $sdk"
+
+grep -Fq '<artifactId>central-publishing-maven-plugin</artifactId>' pom.xml \
+  || die "Central Publisher Portal Maven plugin is not configured"
+grep -Fq '<groupId>org.sonatype.central</groupId>' pom.xml \
+  || die "Central Publisher Portal plugin groupId must be org.sonatype.central"
+grep -Fq '<extensions>true</extensions>' pom.xml \
+  || die "Central Publisher Portal Maven extension must be enabled"
+grep -Fq '<publishingServerId>central</publishingServerId>' pom.xml \
+  || die "Central publishingServerId must be central"
+grep -Fq '<autoPublish>true</autoPublish>' pom.xml \
+  || die "Central plugin must auto-publish successful validated deployments"
+grep -Fq '<waitUntil>published</waitUntil>' pom.xml \
+  || die "Central plugin must wait until publication completes before deploy.sh succeeds"
+assert_central_dry_run_contract "$REPO_ROOT"
+pass "Central Publisher Portal plugin 0.8.0 and its no-upload rehearsal contract are configured"
+
+grep -Fq '<arg>--pinentry-mode</arg>' pom.xml \
+  || die "release signing is missing GPG loopback pinentry configuration"
+grep -Fq '<arg>loopback</arg>' pom.xml \
+  || die "release signing is missing GPG loopback pinentry configuration"
+pass "GPG loopback signing is configured"
+
+settings="${MAVEN_SETTINGS:-${HOME}/.m2/settings.xml}"
+[ -f "$settings" ] || die "Maven settings not found: $settings"
+grep -qE '<id>[[:space:]]*central[[:space:]]*</id>' "$settings" \
+  || die "$settings has no server with id central"
+pass "Maven settings contains the central server entry"
+
+secret_keys="$(gpg --batch --list-secret-keys --with-colons 2>/dev/null || true)"
+grep -q '^sec:' <<< "$secret_keys" \
+  || die "no GPG secret key is available for Maven signing"
+pass "a GPG secret key is available"
+
+gh auth status >/dev/null 2>&1 || die "GitHub CLI is not authenticated; run gh auth login"
+pass "GitHub CLI authentication is available"
+
+echo
+info "${C_GREEN}PREFLIGHT PASSED${C_RESET}"
+printf 'Connector version in pom.xml: %s\n' "$(pom_connector_version "$REPO_ROOT")"
+printf 'Supported Spark versions: %s\n' "${versions[*]}"

--- a/.claude/skills/spark-connector-release/scripts/preflight.sh
+++ b/.claude/skills/spark-connector-release/scripts/preflight.sh
@@ -23,6 +23,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib.sh"
 
+CENTRAL_CREDENTIAL_PROBE=''
+trap '[ -z "$CENTRAL_CREDENTIAL_PROBE" ] || rm -f "$CENTRAL_CREDENTIAL_PROBE"' EXIT
+
 REPO_ROOT="$(resolve_repo)"
 cd "$REPO_ROOT"
 
@@ -32,7 +35,7 @@ pass "repository is a primary checkout"
 assert_clean_checkout "$REPO_ROOT"
 pass "working tree is clean"
 
-for command in git mvn gpg curl unzip zip sha256sum gh; do
+for command in git mvn gpg curl jq base64 unzip zip sha256sum gh; do
   require_command "$command"
   pass "$command is available"
 done
@@ -83,11 +86,11 @@ grep -Fq '<arg>loopback</arg>' pom.xml \
   || die "release signing is missing GPG loopback pinentry configuration"
 pass "GPG loopback signing is configured"
 
-settings="${MAVEN_SETTINGS:-${HOME}/.m2/settings.xml}"
-[ -f "$settings" ] || die "Maven settings not found: $settings"
-grep -qE '<id>[[:space:]]*central[[:space:]]*</id>' "$settings" \
-  || die "$settings has no server with id central"
-pass "Maven settings contains the central server entry"
+CENTRAL_CREDENTIAL_PROBE="$(mktemp /tmp/spark-connector-central-auth.XXXXXX)"
+write_central_curl_config "$CENTRAL_CREDENTIAL_PROBE"
+rm -f "$CENTRAL_CREDENTIAL_PROBE"
+CENTRAL_CREDENTIAL_PROBE=''
+pass "Central Portal API credentials are available"
 
 secret_keys="$(gpg --batch --list-secret-keys --with-colons 2>/dev/null || true)"
 grep -q '^sec:' <<< "$secret_keys" \

--- a/.claude/skills/spark-connector-release/scripts/preflight.sh
+++ b/.claude/skills/spark-connector-release/scripts/preflight.sh
@@ -40,9 +40,7 @@ for command in git mvn gpg curl jq base64 unzip zip sha256sum gh; do
   pass "$command is available"
 done
 
-origin_url="$(git remote get-url origin 2>/dev/null || true)"
-[[ "$origin_url" == *StarRocks/starrocks-connector-for-apache-spark* ]] \
-  || die "origin is not the StarRocks Spark connector repository: ${origin_url:-<missing>}"
+assert_official_origin "$REPO_ROOT"
 pass "origin points to StarRocks/starrocks-connector-for-apache-spark"
 
 mapfile -t versions < <(supported_spark_versions "$REPO_ROOT")

--- a/.claude/skills/spark-connector-release/scripts/prepare_release.sh
+++ b/.claude/skills/spark-connector-release/scripts/prepare_release.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Modifications Copyright 2021 StarRocks Limited.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib.sh"
+
+VERSION="${1:-}"
+[ -n "$VERSION" ] || die "usage: prepare_release.sh <version>"
+validate_release_version "$VERSION"
+
+REPO_ROOT="$(resolve_repo)"
+cd "$REPO_ROOT"
+assert_primary_checkout "$REPO_ROOT"
+assert_clean_checkout "$REPO_ROOT"
+require_command mvn
+
+BRANCH="release-$VERSION"
+TAG="v$VERSION"
+git check-ref-format --branch "$BRANCH" >/dev/null \
+  || die "invalid release branch name: $BRANCH"
+
+info "Fetching the latest main branch and tags"
+git fetch origin main --tags
+
+git show-ref --verify --quiet "refs/heads/$BRANCH" \
+  && die "local branch $BRANCH already exists; inspect it instead of overwriting it"
+git show-ref --verify --quiet "refs/tags/$TAG" \
+  && die "local tag $TAG already exists; tags are never overwritten by this workflow"
+[ -z "$(git ls-remote --heads origin "refs/heads/$BRANCH")" ] \
+  || die "origin branch $BRANCH already exists"
+[ -z "$(git ls-remote --tags origin "refs/tags/$TAG")" ] \
+  || die "origin tag $TAG already exists; a published release version cannot be reused"
+
+current="$(git show origin/main:pom.xml | awk '
+  index($0, "<artifactId>starrocks-spark-connector-${env.SPARK_FEATURE_VERSION}_${env.STARROCKS_SCALA_VERSION}</artifactId>") { found = 1; next }
+  found && /<version>[^<]+<\/version>/ {
+    line = $0
+    sub(/^.*<version>/, "", line)
+    sub(/<\/version>.*$/, "", line)
+    print line
+    exit
+  }
+')"
+[ -n "$current" ] || die "cannot determine connector version from origin/main"
+[[ "$current" == *-SNAPSHOT ]] \
+  || die "origin/main version $current is not a SNAPSHOT; inspect repository state before releasing"
+
+info "Creating $BRANCH from origin/main"
+git switch --create "$BRANCH" origin/main
+
+info "Setting connector version $current -> $VERSION"
+mvn --batch-mode versions:set \
+  -DnewVersion="$VERSION" \
+  -DgenerateBackupPoms=false
+
+[ "$(pom_connector_version "$REPO_ROOT")" = "$VERSION" ] \
+  || die "pom.xml did not resolve to release version $VERSION"
+pom_is_snapshot "$REPO_ROOT" && die "pom.xml is still a SNAPSHOT after versions:set"
+
+mapfile -t changed < <(git status --porcelain | awk '{print $2}')
+[ "${#changed[@]}" -eq 1 ] && [ "${changed[0]}" = pom.xml ] \
+  || die "version update changed unexpected files: ${changed[*]:-none}"
+
+git add pom.xml
+git commit -m "Bump version to $VERSION"
+git tag "$TAG"
+
+head="$(git rev-parse HEAD)"
+verify_head_is_tag "$REPO_ROOT" "$VERSION"
+pass "$TAG points to $head"
+
+echo
+info "${C_GREEN}RELEASE COMMIT AND LOCAL TAG READY${C_RESET}"
+printf 'Branch: %s\nTag: %s\nCommit: %s\n' "$BRANCH" "$TAG" "$head"
+printf 'Nothing was pushed. Next run: scripts/build_verify.sh\n'

--- a/.claude/skills/spark-connector-release/scripts/publish.sh
+++ b/.claude/skills/spark-connector-release/scripts/publish.sh
@@ -101,7 +101,7 @@ for spark in "${versions[@]}"; do
   [ "$actual_bundle_sha" = "$expected_bundle_sha" ] \
     || die "Central bundle for Spark $spark changed after verification"
   "$SCRIPT_DIR/verify_bundle.sh" \
-    "$bundle" "$jar" "$COMMIT" "$VERSION" "$spark" "$scala" "$java" "$SDK_VERSION" >/dev/null
+    "$bundle" "$jar" "$COMMIT" "$VERSION" "$spark" "$scala" "$SDK_VERSION" >/dev/null
   pass "verified signed Central bundle is intact for Spark $spark"
 
   url="$(central_artifact_url "$VERSION" "$spark" "$scala")"

--- a/.claude/skills/spark-connector-release/scripts/publish.sh
+++ b/.claude/skills/spark-connector-release/scripts/publish.sh
@@ -27,6 +27,7 @@ REPO_ROOT="$(resolve_repo)"
 cd "$REPO_ROOT"
 assert_primary_checkout "$REPO_ROOT"
 assert_clean_checkout "$REPO_ROOT"
+assert_official_origin "$REPO_ROOT"
 CENTRAL_CURL_CONFIG=''
 trap '[ -z "$CENTRAL_CURL_CONFIG" ] || rm -f "$CENTRAL_CURL_CONFIG"' EXIT
 for command in curl jq base64 sha256sum; do require_command "$command"; done

--- a/.claude/skills/spark-connector-release/scripts/publish.sh
+++ b/.claude/skills/spark-connector-release/scripts/publish.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Modifications Copyright 2021 StarRocks Limited.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib.sh"
+
+REPO_ROOT="$(resolve_repo)"
+cd "$REPO_ROOT"
+assert_primary_checkout "$REPO_ROOT"
+assert_clean_checkout "$REPO_ROOT"
+trap 'cleanup_maven_generated_files "$REPO_ROOT"' EXIT
+require_command curl
+
+for variable in CUSTOM_MVN MAVEN_ARGS MAVEN_OPTS JAVA_TOOL_OPTIONS _JAVA_OPTIONS JDK_JAVA_OPTIONS; do
+  value="${!variable:-}"
+  [[ "$value" != *skipPublishing* ]] \
+    || die "$variable contains skipPublishing; refusing to record a false publication success"
+done
+for config in .mvn/maven.config .mvn/jvm.config; do
+  [ ! -f "$config" ] \
+    || ! grep -q 'skipPublishing' "$config" \
+    || die "$config contains skipPublishing; remove it before publication"
+done
+
+VERSION="$(pom_connector_version "$REPO_ROOT")"
+[ -n "$VERSION" ] || die "cannot determine connector version"
+pom_is_snapshot "$REPO_ROOT" && die "pom.xml is still a SNAPSHOT"
+verify_head_is_tag "$REPO_ROOT" "$VERSION"
+COMMIT="$(git rev-parse HEAD)"
+verify_tag_on_origin "$REPO_ROOT" "$VERSION" "$COMMIT"
+pass "origin tag v$VERSION points to $COMMIT"
+
+mapfile -t versions < <(resolve_versions "$REPO_ROOT" "$@")
+[ "${#versions[@]}" -gt 0 ] || die "no Spark versions selected"
+
+STATE_DIR="$(release_state_dir "$REPO_ROOT" "$VERSION")"
+MARKER="$STATE_DIR/verified.env"
+[ -f "$MARKER" ] || die "no local verification marker; run build_verify.sh first"
+[ "$(sed -n 's/^commit=//p' "$MARKER")" = "$COMMIT" ] \
+  || die "verification marker does not match current commit $COMMIT"
+[ "$(sed -n 's/^version=//p' "$MARKER")" = "$VERSION" ] \
+  || die "verification marker does not match connector version $VERSION"
+verified="$(sed -n 's/^versions=//p' "$MARKER")"
+SDK_VERSION="$(stream_load_sdk_version "$REPO_ROOT")"
+MAVEN_CMD="$(release_maven_command)"
+
+for spark in "${versions[@]}"; do
+  case " $verified " in
+    *" $spark "*) ;;
+    *) die "Spark $spark was not verified by build_verify.sh (verified: ${verified:-none})" ;;
+  esac
+  [ ! -f "$STATE_DIR/published-$spark.env" ] \
+    || die "local state says Spark $spark was already published; never redeploy the same coordinates"
+  [ ! -f "$STATE_DIR/publishing-$spark.env" ] \
+    || die "a previous Spark $spark publication was interrupted; inspect Central Portal, then remove the in-flight marker only after proving the coordinate was not uploaded"
+
+  scala="$(spark_scala_binary "$REPO_ROOT" "$spark")"
+  java="$(spark_java_major "$REPO_ROOT" "$spark")"
+  filename="$(artifact_filename "$VERSION" "$spark" "$scala")"
+  jar="$STATE_DIR/artifacts/$filename"
+  bundle="$STATE_DIR/bundles/central-bundle-spark-$spark.zip"
+  meta="$STATE_DIR/verified-$spark.env"
+  [ -f "$jar" ] && [ -f "$bundle" ] && [ -f "$meta" ] \
+    || die "verified artifact state is incomplete for Spark $spark"
+  [ "$(sed -n 's/^commit=//p' "$meta")" = "$COMMIT" ] \
+    || die "verification metadata for Spark $spark belongs to another commit"
+  [ "$(sed -n 's/^spark=//p' "$meta")" = "$spark" ] \
+    || die "verification metadata has the wrong Spark version for $spark"
+  [ "$(sed -n 's/^scala=//p' "$meta")" = "$scala" ] \
+    || die "verification metadata has the wrong Scala version for Spark $spark"
+  [ "$(sed -n 's/^java=//p' "$meta")" = "$java" ] \
+    || die "verification metadata has the wrong Java version for Spark $spark"
+  [ "$(sed -n 's/^artifact=//p' "$meta")" = "$filename" ] \
+    || die "verification metadata has the wrong artifact for Spark $spark"
+  [ "$(sed -n 's/^bundle=//p' "$meta")" = "$(basename "$bundle")" ] \
+    || die "verification metadata has the wrong Central bundle for Spark $spark"
+  expected_sha="$(sed -n 's/^sha256=//p' "$meta")"
+  actual_sha="$(sha256sum "$jar" | awk '{print $1}')"
+  [ "$actual_sha" = "$expected_sha" ] || die "$filename changed after verification"
+  expected_bundle_sha="$(sed -n 's/^bundle_sha256=//p' "$meta")"
+  actual_bundle_sha="$(sha256sum "$bundle" | awk '{print $1}')"
+  [ "$actual_bundle_sha" = "$expected_bundle_sha" ] \
+    || die "Central bundle for Spark $spark changed after verification"
+  "$SCRIPT_DIR/verify_bundle.sh" \
+    "$bundle" "$jar" "$COMMIT" "$VERSION" "$spark" "$scala" "$java" "$SDK_VERSION" >/dev/null
+  pass "verified signed Central bundle is intact for Spark $spark"
+
+  url="$(central_artifact_url "$VERSION" "$spark" "$scala")"
+  status="$(curl -sS --connect-timeout 15 --max-time 30 -o /dev/null -w '%{http_code}' "$url" || true)"
+  case "$status" in
+    404) pass "coordinates are not present on Maven Central for Spark $spark" ;;
+    200) die "$url already exists; Maven Central releases are immutable" ;;
+    000|'') die "could not check Maven Central for existing Spark $spark coordinates" ;;
+    *) die "unexpected Maven Central response $status while checking $url" ;;
+  esac
+done
+
+echo
+warn "This will publish immutable artifacts through Central Publisher Portal:"
+for spark in "${versions[@]}"; do
+  scala="$(spark_scala_binary "$REPO_ROOT" "$spark")"
+  printf '  com.starrocks:%s:%s\n' "$(artifact_id "$spark" "$scala")" "$VERSION"
+done
+if [ -t 0 ]; then
+  printf 'Type the release version "%s" to publish: ' "$VERSION"
+  read -r answer
+  [ "$answer" = "$VERSION" ] || die "confirmation mismatch; publication aborted"
+else
+  [ "${CONFIRM_PUBLISH:-}" = "$VERSION" ] \
+    || die "non-interactive publication requires CONFIRM_PUBLISH=$VERSION"
+fi
+
+declare -a results=()
+for spark in "${versions[@]}"; do
+  java="$(spark_java_major "$REPO_ROOT" "$spark")"
+  info "Publishing Spark $spark with JDK $java"
+  activate_java_for_spark "$REPO_ROOT" "$spark"
+  {
+    printf 'commit=%s\n' "$COMMIT"
+    printf 'version=%s\n' "$VERSION"
+    printf 'spark=%s\n' "$spark"
+    printf 'started_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  } > "$STATE_DIR/publishing-$spark.env"
+  if CUSTOM_MVN="$MAVEN_CMD" bash deploy.sh "$spark"; then
+    {
+      printf 'commit=%s\n' "$COMMIT"
+      printf 'version=%s\n' "$VERSION"
+      printf 'spark=%s\n' "$spark"
+      printf 'published_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    } > "$STATE_DIR/published-$spark.env"
+    rm -f "$STATE_DIR/publishing-$spark.env"
+    results+=("Spark $spark PUBLISHED")
+    pass "published Spark $spark"
+  else
+    results+=("Spark $spark FAILED")
+    printf '\n'
+    for result in "${results[@]}"; do printf '  %s\n' "$result"; done
+    die "publication failed for Spark $spark; inspect Central Portal before retrying only this version"
+  fi
+done
+
+echo
+info "${C_GREEN}PUBLICATION COMPLETE${C_RESET}"
+for result in "${results[@]}"; do printf '  %s\n' "$result"; done
+printf 'Next run: scripts/verify_central.sh %s\n' "$VERSION"

--- a/.claude/skills/spark-connector-release/scripts/publish.sh
+++ b/.claude/skills/spark-connector-release/scripts/publish.sh
@@ -27,19 +27,9 @@ REPO_ROOT="$(resolve_repo)"
 cd "$REPO_ROOT"
 assert_primary_checkout "$REPO_ROOT"
 assert_clean_checkout "$REPO_ROOT"
-trap 'cleanup_maven_generated_files "$REPO_ROOT"' EXIT
-require_command curl
-
-for variable in CUSTOM_MVN MAVEN_ARGS MAVEN_OPTS JAVA_TOOL_OPTIONS _JAVA_OPTIONS JDK_JAVA_OPTIONS; do
-  value="${!variable:-}"
-  [[ "$value" != *skipPublishing* ]] \
-    || die "$variable contains skipPublishing; refusing to record a false publication success"
-done
-for config in .mvn/maven.config .mvn/jvm.config; do
-  [ ! -f "$config" ] \
-    || ! grep -q 'skipPublishing' "$config" \
-    || die "$config contains skipPublishing; remove it before publication"
-done
+CENTRAL_CURL_CONFIG=''
+trap '[ -z "$CENTRAL_CURL_CONFIG" ] || rm -f "$CENTRAL_CURL_CONFIG"' EXIT
+for command in curl jq base64 sha256sum; do require_command "$command"; done
 
 VERSION="$(pom_connector_version "$REPO_ROOT")"
 [ -n "$VERSION" ] || die "cannot determine connector version"
@@ -61,7 +51,6 @@ MARKER="$STATE_DIR/verified.env"
   || die "verification marker does not match connector version $VERSION"
 verified="$(sed -n 's/^versions=//p' "$MARKER")"
 SDK_VERSION="$(stream_load_sdk_version "$REPO_ROOT")"
-MAVEN_CMD="$(release_maven_command)"
 
 for spark in "${versions[@]}"; do
   case " $verified " in
@@ -129,33 +118,40 @@ else
     || die "non-interactive publication requires CONFIRM_PUBLISH=$VERSION"
 fi
 
+CENTRAL_CURL_CONFIG="$(mktemp /tmp/spark-connector-central-curl.XXXXXX)"
+write_central_curl_config "$CENTRAL_CURL_CONFIG"
+pass "Central Portal API credentials are loaded without logging them"
+
 declare -a results=()
 for spark in "${versions[@]}"; do
-  java="$(spark_java_major "$REPO_ROOT" "$spark")"
-  info "Publishing Spark $spark with JDK $java"
-  activate_java_for_spark "$REPO_ROOT" "$spark"
+  scala="$(spark_scala_binary "$REPO_ROOT" "$spark")"
+  artifact="$(artifact_id "$spark" "$scala")"
+  bundle="$STATE_DIR/bundles/central-bundle-spark-$spark.zip"
+  bundle_sha="$(sha256sum "$bundle" | awk '{print $1}')"
+  in_flight_marker="$STATE_DIR/publishing-$spark.env"
+  info "Publishing the verified Central bundle for Spark $spark"
   {
     printf 'commit=%s\n' "$COMMIT"
     printf 'version=%s\n' "$VERSION"
     printf 'spark=%s\n' "$spark"
+    printf 'bundle=%s\n' "$(basename "$bundle")"
     printf 'started_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  } > "$STATE_DIR/publishing-$spark.env"
-  if CUSTOM_MVN="$MAVEN_CMD" bash deploy.sh "$spark"; then
-    {
-      printf 'commit=%s\n' "$COMMIT"
-      printf 'version=%s\n' "$VERSION"
-      printf 'spark=%s\n' "$spark"
-      printf 'published_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-    } > "$STATE_DIR/published-$spark.env"
-    rm -f "$STATE_DIR/publishing-$spark.env"
-    results+=("Spark $spark PUBLISHED")
-    pass "published Spark $spark"
-  else
-    results+=("Spark $spark FAILED")
-    printf '\n'
-    for result in "${results[@]}"; do printf '  %s\n' "$result"; done
-    die "publication failed for Spark $spark; inspect Central Portal before retrying only this version"
-  fi
+  } > "$in_flight_marker"
+  publish_verified_bundle \
+    "$bundle" "com.starrocks:$artifact:$VERSION" "$CENTRAL_CURL_CONFIG" "$in_flight_marker"
+  deployment_id="$(sed -n 's/^deployment_id=//p' "$in_flight_marker")"
+  {
+    printf 'commit=%s\n' "$COMMIT"
+    printf 'version=%s\n' "$VERSION"
+    printf 'spark=%s\n' "$spark"
+    printf 'bundle=%s\n' "$(basename "$bundle")"
+    printf 'bundle_sha256=%s\n' "$bundle_sha"
+    printf 'deployment_id=%s\n' "$deployment_id"
+    printf 'published_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  } > "$STATE_DIR/published-$spark.env"
+  rm -f "$in_flight_marker"
+  results+=("Spark $spark PUBLISHED")
+  pass "published Spark $spark from Central deployment $deployment_id"
 done
 
 echo

--- a/.claude/skills/spark-connector-release/scripts/verify_bundle.sh
+++ b/.claude/skills/spark-connector-release/scripts/verify_bundle.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Modifications Copyright 2021 StarRocks Limited.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib.sh"
+
+BUNDLE="${1:-}"
+LOCAL_JAR="${2:-}"
+EXPECTED_COMMIT="${3:-}"
+EXPECTED_VERSION="${4:-}"
+SPARK_MINOR="${5:-}"
+SCALA_BINARY="${6:-}"
+JAVA_MAJOR="${7:-}"
+SDK_VERSION="${8:-}"
+[ "$#" -eq 8 ] \
+  || die "usage: verify_bundle.sh <bundle.zip> <local-jar> <commit> <version> <spark-minor> <scala-binary> <java-major> <sdk-version>"
+[ -s "$BUNDLE" ] || die "Central bundle not found: $BUNDLE"
+[ -s "$LOCAL_JAR" ] || die "local primary JAR not found: $LOCAL_JAR"
+
+for command in unzip gpg md5sum sha1sum sha256sum sha512sum; do
+  require_command "$command"
+done
+
+ARTIFACT="$(artifact_id "$SPARK_MINOR" "$SCALA_BINARY")"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+unzip -q "$BUNDLE" -d "$WORK"
+BASE="$WORK/com/starrocks/$ARTIFACT/$EXPECTED_VERSION/$ARTIFACT-$EXPECTED_VERSION"
+
+for file in "$BASE.pom" "$BASE.jar" "$BASE-sources.jar" "$BASE-javadoc.jar"; do
+  [ -s "$file" ] || die "Central bundle is missing ${file#"$WORK/"}"
+  [ -s "$file.asc" ] || die "Central bundle is missing signature ${file#"$WORK/"}.asc"
+  gpg --batch --verify "$file.asc" "$file" >/dev/null 2>&1 \
+    || die "GPG verification failed for ${file#"$WORK/"}"
+  for algorithm in md5 sha1 sha256 sha512; do
+    checksum_file="$file.$algorithm"
+    [ -s "$checksum_file" ] || die "Central bundle is missing ${checksum_file#"$WORK/"}"
+    expected="$(tr -d '[:space:]' < "$checksum_file")"
+    actual="$("${algorithm}sum" "$file" | awk '{print $1}')"
+    [ "$actual" = "$expected" ] \
+      || die "$algorithm checksum mismatch for ${file#"$WORK/"}"
+  done
+done
+
+grep -q '<version>.*SNAPSHOT.*</version>' "$BASE.pom" \
+  && die "flattened release POM still contains a project SNAPSHOT version"
+cmp -s "$LOCAL_JAR" "$BASE.jar" \
+  || die "primary JAR in Central bundle differs from target/ primary JAR"
+
+"$SCRIPT_DIR/verify_jar.sh" \
+  "$BASE.jar" "$EXPECTED_COMMIT" "$EXPECTED_VERSION" "$SPARK_MINOR" \
+  "$SCALA_BINARY" "$JAVA_MAJOR" "$SDK_VERSION"
+pass "Central bundle contains signed primary, sources, Javadocs, POM, and checksums"

--- a/.claude/skills/spark-connector-release/scripts/verify_bundle.sh
+++ b/.claude/skills/spark-connector-release/scripts/verify_bundle.sh
@@ -29,10 +29,9 @@ EXPECTED_COMMIT="${3:-}"
 EXPECTED_VERSION="${4:-}"
 SPARK_MINOR="${5:-}"
 SCALA_BINARY="${6:-}"
-JAVA_MAJOR="${7:-}"
-SDK_VERSION="${8:-}"
-[ "$#" -eq 8 ] \
-  || die "usage: verify_bundle.sh <bundle.zip> <local-jar> <commit> <version> <spark-minor> <scala-binary> <java-major> <sdk-version>"
+SDK_VERSION="${7:-}"
+[ "$#" -eq 7 ] \
+  || die "usage: verify_bundle.sh <bundle.zip> <local-jar> <commit> <version> <spark-minor> <scala-binary> <sdk-version>"
 [ -s "$BUNDLE" ] || die "Central bundle not found: $BUNDLE"
 [ -s "$LOCAL_JAR" ] || die "local primary JAR not found: $LOCAL_JAR"
 
@@ -68,5 +67,5 @@ cmp -s "$LOCAL_JAR" "$BASE.jar" \
 
 "$SCRIPT_DIR/verify_jar.sh" \
   "$BASE.jar" "$EXPECTED_COMMIT" "$EXPECTED_VERSION" "$SPARK_MINOR" \
-  "$SCALA_BINARY" "$JAVA_MAJOR" "$SDK_VERSION"
+  "$SCALA_BINARY" "$SDK_VERSION"
 pass "Central bundle contains signed primary, sources, Javadocs, POM, and checksums"

--- a/.claude/skills/spark-connector-release/scripts/verify_central.sh
+++ b/.claude/skills/spark-connector-release/scripts/verify_central.sh
@@ -65,7 +65,6 @@ download_file() {
 
 for spark in "${versions[@]}"; do
   scala="$(spark_scala_binary "$REPO_ROOT" "$spark")"
-  java="$(spark_java_major "$REPO_ROOT" "$spark")"
   artifact="$(artifact_id "$spark" "$scala")"
   filename="$(artifact_filename "$VERSION" "$spark" "$scala")"
   destination="$DOWNLOAD_DIR/$filename"
@@ -97,7 +96,7 @@ for spark in "${versions[@]}"; do
     && die "published POM for Spark $spark contains a project SNAPSHOT version"
 
   if "$SCRIPT_DIR/verify_jar.sh" \
-      "$destination" "$COMMIT" "$VERSION" "$spark" "$scala" "$java" "$SDK_VERSION"; then
+      "$destination" "$COMMIT" "$VERSION" "$spark" "$scala" "$SDK_VERSION"; then
     sha="$(sha256sum "$destination" | awk '{print $1}')"
     {
       printf 'commit=%s\n' "$COMMIT"

--- a/.claude/skills/spark-connector-release/scripts/verify_central.sh
+++ b/.claude/skills/spark-connector-release/scripts/verify_central.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Modifications Copyright 2021 StarRocks Limited.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib.sh"
+
+VERSION="${1:-}"
+[ -n "$VERSION" ] || die "usage: verify_central.sh <version> [spark-minor ...]"
+validate_release_version "$VERSION"
+shift
+
+REPO_ROOT="$(resolve_repo)"
+cd "$REPO_ROOT"
+assert_primary_checkout "$REPO_ROOT"
+[ "$(pom_connector_version "$REPO_ROOT")" = "$VERSION" ] \
+  || die "current pom version does not equal $VERSION; checkout tag v$VERSION"
+verify_head_is_tag "$REPO_ROOT" "$VERSION"
+COMMIT="$(git rev-parse HEAD)"
+verify_tag_on_origin "$REPO_ROOT" "$VERSION" "$COMMIT"
+pass "origin tag v$VERSION points to $COMMIT"
+SDK_VERSION="$(stream_load_sdk_version "$REPO_ROOT")"
+require_command curl
+require_command gpg
+
+mapfile -t versions < <(resolve_versions "$REPO_ROOT" "$@")
+[ "${#versions[@]}" -gt 0 ] || die "no Spark versions selected"
+
+STATE_DIR="$(release_state_dir "$REPO_ROOT" "$VERSION")"
+DOWNLOAD_DIR="$STATE_DIR/central"
+mkdir -p "$DOWNLOAD_DIR"
+
+declare -a results=()
+overall=0
+
+download_file() {
+  local url="$1" destination="$2" attempt
+  for attempt in 1 2 3 4 5 6; do
+    if curl -fsSL --connect-timeout 20 --max-time 180 -o "$destination" "$url"; then
+      return
+    fi
+    warn "download attempt $attempt failed; Central may still be synchronizing: $url"
+    [ "$attempt" -eq 6 ] || sleep 15
+  done
+  return 1
+}
+
+for spark in "${versions[@]}"; do
+  scala="$(spark_scala_binary "$REPO_ROOT" "$spark")"
+  java="$(spark_java_major "$REPO_ROOT" "$spark")"
+  artifact="$(artifact_id "$spark" "$scala")"
+  filename="$(artifact_filename "$VERSION" "$spark" "$scala")"
+  destination="$DOWNLOAD_DIR/$filename"
+  url="$(central_artifact_url "$VERSION" "$spark" "$scala")"
+  base_url="${url%.jar}"
+
+  info "Downloading published Spark $spark artifacts and signatures"
+  downloaded=1
+  for suffix in .pom .jar -sources.jar -javadoc.jar; do
+    published_file="$DOWNLOAD_DIR/$artifact-$VERSION$suffix"
+    if ! download_file "$base_url$suffix" "$published_file" \
+        || ! download_file "$base_url$suffix.asc" "$published_file.asc"; then
+      downloaded=0
+      break
+    fi
+    if ! gpg --batch --verify "$published_file.asc" "$published_file" >/dev/null 2>&1; then
+      fail "GPG verification failed for $(basename "$published_file")"
+      downloaded=0
+      break
+    fi
+  done
+  if [ "$downloaded" -ne 1 ]; then
+    fail "could not verify the complete published artifact set for Spark $spark"
+    results+=("Spark $spark FAIL(download)")
+    overall=1
+    continue
+  fi
+  grep -q '<version>.*SNAPSHOT.*</version>' "$DOWNLOAD_DIR/$artifact-$VERSION.pom" \
+    && die "published POM for Spark $spark contains a project SNAPSHOT version"
+
+  if "$SCRIPT_DIR/verify_jar.sh" \
+      "$destination" "$COMMIT" "$VERSION" "$spark" "$scala" "$java" "$SDK_VERSION"; then
+    sha="$(sha256sum "$destination" | awk '{print $1}')"
+    {
+      printf 'commit=%s\n' "$COMMIT"
+      printf 'version=%s\n' "$VERSION"
+      printf 'spark=%s\n' "$spark"
+      printf 'artifact=%s\n' "$filename"
+      printf 'sha256=%s\n' "$sha"
+    } > "$STATE_DIR/central-verified-$spark.env"
+    results+=("Spark $spark OK")
+  else
+    results+=("Spark $spark FAIL(verify)")
+    overall=1
+  fi
+done
+
+echo
+info "Maven Central verification summary"
+for result in "${results[@]}"; do printf '  %s\n' "$result"; done
+
+if [ "$overall" -ne 0 ]; then
+  die "one or more published artifacts failed verification"
+fi
+info "${C_GREEN}PUBLISHED ARTIFACTS VERIFIED${C_RESET}: ${versions[*]}"

--- a/.claude/skills/spark-connector-release/scripts/verify_jar.sh
+++ b/.claude/skills/spark-connector-release/scripts/verify_jar.sh
@@ -28,16 +28,14 @@ EXPECTED_COMMIT="${2:-}"
 EXPECTED_VERSION="${3:-}"
 SPARK_MINOR="${4:-}"
 SCALA_BINARY="${5:-}"
-JAVA_MAJOR="${6:-}"
-SDK_VERSION="${7:-}"
+SDK_VERSION="${6:-}"
 
-[ "$#" -eq 7 ] \
-  || die "usage: verify_jar.sh <jar> <commit> <version> <spark-minor> <scala-binary> <java-major> <sdk-version>"
+[ "$#" -eq 6 ] \
+  || die "usage: verify_jar.sh <jar> <commit> <version> <spark-minor> <scala-binary> <sdk-version>"
 [ -f "$JAR" ] || die "JAR not found: $JAR"
 [[ "$EXPECTED_COMMIT" =~ ^[0-9a-fA-F]{40}$ ]] || die "expected commit must be a full 40-character Git SHA"
 
 require_command unzip
-require_command od
 
 ARTIFACT="$(artifact_id "$SPARK_MINOR" "$SCALA_BINARY")"
 EXPECTED_FILE="$(artifact_filename "$EXPECTED_VERSION" "$SPARK_MINOR" "$SCALA_BINARY")"
@@ -46,7 +44,6 @@ CONNECTOR_PROPERTIES="starrocks-spark-connector-git.properties"
 SDK_POM_PROPERTIES="META-INF/maven/com.starrocks/starrocks-stream-load-sdk/pom.properties"
 SDK_GIT_PROPERTIES="stream-load-sdk-git.properties"
 SDK_CLASS_PREFIX="com/starrocks/data/load/stream/"
-EXPECTED_CLASS_MAJOR="$(expected_class_major "$JAVA_MAJOR")"
 
 ok=0
 bad=0
@@ -59,7 +56,7 @@ case "$(basename "$JAR")" in
     ;;
 esac
 
-info "Verifying $(basename "$JAR") for Spark $SPARK_MINOR / Scala $SCALA_BINARY / Java $JAVA_MAJOR"
+info "Verifying $(basename "$JAR") for Spark $SPARK_MINOR / Scala $SCALA_BINARY"
 if [ "$(basename "$JAR")" = "$EXPECTED_FILE" ]; then
   yes "filename matches $EXPECTED_FILE"
 else
@@ -134,37 +131,8 @@ class_list="$(printf '%s\n' "$LIST" | awk '/^com\/starrocks\/connector\/spark\/.
 if [ -z "$class_list" ]; then
   no "no connector-owned class files found"
 else
-  class_count=0
-  class_mismatch=0
-  class_exact=0
-  class_tmp="$(mktemp)"
-  trap 'rm -f "$class_tmp"' EXIT
-  while IFS= read -r entry; do
-    [ -n "$entry" ] || continue
-    class_count=$((class_count + 1))
-    unzip -p "$JAR" "$entry" > "$class_tmp" 2>/dev/null \
-      || die "cannot extract class file $entry"
-    magic="$(od -An -tx1 -N4 "$class_tmp" | tr -d ' \n')"
-    [ "$magic" = cafebabe ] || die "$entry is not a valid Java class file"
-    bytes="$(od -An -tu1 -j6 -N2 "$class_tmp")"
-    read -r high low <<< "$bytes"
-    major=$((high * 256 + low))
-    if [ "$major" -gt "$EXPECTED_CLASS_MAJOR" ]; then
-      fail "bytecode mismatch: $entry has class major $major, newer than $EXPECTED_CLASS_MAJOR for Java $JAVA_MAJOR"
-      class_mismatch=$((class_mismatch + 1))
-    elif [ "$major" -eq "$EXPECTED_CLASS_MAJOR" ]; then
-      class_exact=$((class_exact + 1))
-    fi
-  done <<< "$class_list"
-  rm -f "$class_tmp"
-  trap - EXIT
-  if [ "$class_mismatch" -eq 0 ] && [ "$class_exact" -gt 0 ]; then
-    yes "$class_count connector class files are Java $JAVA_MAJOR compatible; $class_exact use target major $EXPECTED_CLASS_MAJOR"
-  elif [ "$class_mismatch" -eq 0 ]; then
-    no "bytecode does not prove Java $JAVA_MAJOR target: no connector class uses major $EXPECTED_CLASS_MAJOR"
-  else
-    no "$class_mismatch connector class files have incompatible bytecode"
-  fi
+  class_count="$(printf '%s\n' "$class_list" | awk 'NF { count++ } END { print count + 0 }')"
+  yes "$class_count connector-owned class files are present"
 fi
 
 echo

--- a/.claude/skills/spark-connector-release/scripts/verify_jar.sh
+++ b/.claude/skills/spark-connector-release/scripts/verify_jar.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Modifications Copyright 2021 StarRocks Limited.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib.sh"
+
+JAR="${1:-}"
+EXPECTED_COMMIT="${2:-}"
+EXPECTED_VERSION="${3:-}"
+SPARK_MINOR="${4:-}"
+SCALA_BINARY="${5:-}"
+JAVA_MAJOR="${6:-}"
+SDK_VERSION="${7:-}"
+
+[ "$#" -eq 7 ] \
+  || die "usage: verify_jar.sh <jar> <commit> <version> <spark-minor> <scala-binary> <java-major> <sdk-version>"
+[ -f "$JAR" ] || die "JAR not found: $JAR"
+[[ "$EXPECTED_COMMIT" =~ ^[0-9a-fA-F]{40}$ ]] || die "expected commit must be a full 40-character Git SHA"
+
+require_command unzip
+require_command od
+
+ARTIFACT="$(artifact_id "$SPARK_MINOR" "$SCALA_BINARY")"
+EXPECTED_FILE="$(artifact_filename "$EXPECTED_VERSION" "$SPARK_MINOR" "$SCALA_BINARY")"
+POM_PROPERTIES="META-INF/maven/com.starrocks/$ARTIFACT/pom.properties"
+CONNECTOR_PROPERTIES="starrocks-spark-connector-git.properties"
+SDK_POM_PROPERTIES="META-INF/maven/com.starrocks/starrocks-stream-load-sdk/pom.properties"
+SDK_GIT_PROPERTIES="stream-load-sdk-git.properties"
+SDK_CLASS_PREFIX="com/starrocks/data/load/stream/"
+EXPECTED_CLASS_MAJOR="$(expected_class_major "$JAVA_MAJOR")"
+
+ok=0
+bad=0
+yes() { pass "$1"; ok=$((ok + 1)); }
+no()  { fail "$1"; bad=$((bad + 1)); }
+
+case "$(basename "$JAR")" in
+  original-*|*-sources.jar|*-javadoc.jar)
+    die "$(basename "$JAR") is not the primary shaded connector JAR"
+    ;;
+esac
+
+info "Verifying $(basename "$JAR") for Spark $SPARK_MINOR / Scala $SCALA_BINARY / Java $JAVA_MAJOR"
+if [ "$(basename "$JAR")" = "$EXPECTED_FILE" ]; then
+  yes "filename matches $EXPECTED_FILE"
+else
+  no "filename $(basename "$JAR") != expected $EXPECTED_FILE"
+fi
+
+LIST="$(unzip -Z1 "$JAR" 2>/dev/null)" || die "cannot read ZIP directory from $JAR"
+
+pom="$(unzip -p "$JAR" "$POM_PROPERTIES" 2>/dev/null || true)"
+if [ -n "$pom" ]; then
+  yes "$POM_PROPERTIES is present"
+  pom_group="$(printf '%s\n' "$pom" | property_value groupId)"
+  pom_artifact="$(printf '%s\n' "$pom" | property_value artifactId)"
+  pom_version="$(printf '%s\n' "$pom" | property_value version)"
+  [ "$pom_group" = com.starrocks ] && yes "groupId is com.starrocks" || no "groupId is ${pom_group:-<missing>}"
+  [ "$pom_artifact" = "$ARTIFACT" ] && yes "artifactId is $ARTIFACT" || no "artifactId is ${pom_artifact:-<missing>}, expected $ARTIFACT"
+  [ "$pom_version" = "$EXPECTED_VERSION" ] && yes "artifact version is $EXPECTED_VERSION" || no "artifact version is ${pom_version:-<missing>}, expected $EXPECTED_VERSION"
+  [[ "$pom_version" != *SNAPSHOT* ]] && yes "artifact version is not a snapshot" || no "artifact version contains SNAPSHOT"
+else
+  no "$POM_PROPERTIES is missing"
+fi
+
+connector="$(unzip -p "$JAR" "$CONNECTOR_PROPERTIES" 2>/dev/null || true)"
+if [ -n "$connector" ]; then
+  yes "$CONNECTOR_PROPERTIES is present"
+  connector_version="$(printf '%s\n' "$connector" | property_value git.build.version)"
+  connector_commit="$(printf '%s\n' "$connector" | property_value git.commit.id)"
+  [ "$connector_version" = "$EXPECTED_VERSION" ] \
+    && yes "embedded connector version is $EXPECTED_VERSION" \
+    || no "embedded connector version is ${connector_version:-<missing>}, expected $EXPECTED_VERSION"
+  [[ "$connector_version" != *SNAPSHOT* ]] \
+    && yes "embedded connector version is not a snapshot" \
+    || no "embedded connector version contains SNAPSHOT"
+  [ "$connector_commit" = "$EXPECTED_COMMIT" ] \
+    && yes "embedded connector commit matches the release tag" \
+    || no "embedded connector commit is ${connector_commit:-<missing>}, expected $EXPECTED_COMMIT"
+else
+  no "$CONNECTOR_PROPERTIES is missing; do not release from a linked worktree"
+fi
+
+sdk_pom="$(unzip -p "$JAR" "$SDK_POM_PROPERTIES" 2>/dev/null || true)"
+if [ -n "$sdk_pom" ]; then
+  yes "$SDK_POM_PROPERTIES is present"
+  bundled_sdk_version="$(printf '%s\n' "$sdk_pom" | property_value version)"
+  [ "$bundled_sdk_version" = "$SDK_VERSION" ] \
+    && yes "bundled Stream Load SDK version is $SDK_VERSION" \
+    || no "bundled Stream Load SDK version is ${bundled_sdk_version:-<missing>}, expected $SDK_VERSION"
+else
+  no "$SDK_POM_PROPERTIES is missing"
+fi
+
+sdk_git="$(unzip -p "$JAR" "$SDK_GIT_PROPERTIES" 2>/dev/null || true)"
+if [ -n "$sdk_git" ]; then
+  yes "$SDK_GIT_PROPERTIES is present"
+  sdk_git_version="$(printf '%s\n' "$sdk_git" | property_value git.build.version)"
+  [ "$sdk_git_version" = "$SDK_VERSION" ] \
+    && yes "embedded Stream Load SDK Git version is $SDK_VERSION" \
+    || no "embedded Stream Load SDK Git version is ${sdk_git_version:-<missing>}, expected $SDK_VERSION"
+  [[ "$sdk_git_version" != *SNAPSHOT* ]] \
+    && yes "embedded Stream Load SDK Git version is not a snapshot" \
+    || no "embedded Stream Load SDK Git version contains SNAPSHOT"
+else
+  no "$SDK_GIT_PROPERTIES is missing"
+fi
+
+case "$LIST" in
+  *"$SDK_CLASS_PREFIX"*) yes "Stream Load SDK classes are shaded" ;;
+  *) no "Stream Load SDK classes are missing" ;;
+esac
+
+class_list="$(printf '%s\n' "$LIST" | awk '/^com\/starrocks\/connector\/spark\/.*\.class$/')"
+if [ -z "$class_list" ]; then
+  no "no connector-owned class files found"
+else
+  class_count=0
+  class_mismatch=0
+  class_exact=0
+  class_tmp="$(mktemp)"
+  trap 'rm -f "$class_tmp"' EXIT
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    class_count=$((class_count + 1))
+    unzip -p "$JAR" "$entry" > "$class_tmp" 2>/dev/null \
+      || die "cannot extract class file $entry"
+    magic="$(od -An -tx1 -N4 "$class_tmp" | tr -d ' \n')"
+    [ "$magic" = cafebabe ] || die "$entry is not a valid Java class file"
+    bytes="$(od -An -tu1 -j6 -N2 "$class_tmp")"
+    read -r high low <<< "$bytes"
+    major=$((high * 256 + low))
+    if [ "$major" -gt "$EXPECTED_CLASS_MAJOR" ]; then
+      fail "bytecode mismatch: $entry has class major $major, newer than $EXPECTED_CLASS_MAJOR for Java $JAVA_MAJOR"
+      class_mismatch=$((class_mismatch + 1))
+    elif [ "$major" -eq "$EXPECTED_CLASS_MAJOR" ]; then
+      class_exact=$((class_exact + 1))
+    fi
+  done <<< "$class_list"
+  rm -f "$class_tmp"
+  trap - EXIT
+  if [ "$class_mismatch" -eq 0 ] && [ "$class_exact" -gt 0 ]; then
+    yes "$class_count connector class files are Java $JAVA_MAJOR compatible; $class_exact use target major $EXPECTED_CLASS_MAJOR"
+  elif [ "$class_mismatch" -eq 0 ]; then
+    no "bytecode does not prove Java $JAVA_MAJOR target: no connector class uses major $EXPECTED_CLASS_MAJOR"
+  else
+    no "$class_mismatch connector class files have incompatible bytecode"
+  fi
+fi
+
+echo
+if [ "$bad" -eq 0 ]; then
+  info "${C_GREEN}ALL $ok CHECKS PASSED${C_RESET} — $(basename "$JAR")"
+else
+  die "$bad check(s) failed, $ok passed — DO NOT PUBLISH $(basename "$JAR")"
+fi

--- a/.claude/skills/spark-connector-release/scripts/verify_jar.sh
+++ b/.claude/skills/spark-connector-release/scripts/verify_jar.sh
@@ -43,7 +43,6 @@ POM_PROPERTIES="META-INF/maven/com.starrocks/$ARTIFACT/pom.properties"
 CONNECTOR_PROPERTIES="starrocks-spark-connector-git.properties"
 SDK_POM_PROPERTIES="META-INF/maven/com.starrocks/starrocks-stream-load-sdk/pom.properties"
 SDK_GIT_PROPERTIES="stream-load-sdk-git.properties"
-SDK_CLASS_PREFIX="com/starrocks/data/load/stream/"
 
 ok=0
 bad=0
@@ -122,10 +121,15 @@ else
   no "$SDK_GIT_PROPERTIES is missing"
 fi
 
-case "$LIST" in
-  *"$SDK_CLASS_PREFIX"*) yes "Stream Load SDK classes are shaded" ;;
-  *) no "Stream Load SDK classes are missing" ;;
-esac
+sdk_class_list="$(printf '%s\n' "$LIST" \
+  | awk '/^com\/starrocks\/data\/load\/stream\/.*\.class$/')"
+if [ -z "$sdk_class_list" ]; then
+  no "Stream Load SDK classes are missing"
+else
+  sdk_class_count="$(printf '%s\n' "$sdk_class_list" \
+    | awk 'NF { count++ } END { print count + 0 }')"
+  yes "$sdk_class_count Stream Load SDK class files are shaded"
+fi
 
 class_list="$(printf '%s\n' "$LIST" | awk '/^com\/starrocks\/connector\/spark\/.*\.class$/')"
 if [ -z "$class_list" ]; then

--- a/.claude/skills/spark-connector-release/tests/run_tests.sh
+++ b/.claude/skills/spark-connector-release/tests/run_tests.sh
@@ -183,6 +183,39 @@ test_linked_worktree_rejected() {
   [ "$status" -ne 0 ] && [[ "$output" == *"linked Git worktree"* ]]
 }
 
+test_publish_rechecks_official_origin() {
+  local work repo fork output status
+  work="$(mktemp -d)"
+  repo="$work/repo"
+  fork="$work/lookalike/StarRocks/starrocks-connector-for-apache-spark-fork.git"
+  mkdir -p "$repo"
+  mkdir -p "$(dirname "$fork")"
+  git init --quiet --bare "$fork"
+  git init --quiet "$repo"
+  git -C "$repo" config user.name 'Release Test'
+  git -C "$repo" config user.email 'release-test@example.com'
+  printf '%s\n' \
+    '<project>' \
+    '  <artifactId>starrocks-spark-connector-${env.SPARK_FEATURE_VERSION}_${env.STARROCKS_SCALA_VERSION}</artifactId>' \
+    '  <version>1.2.3</version>' \
+    '</project>' > "$repo/pom.xml"
+  printf '%s\n' 'SUPPORTED_SPARK_VERSIONS=(3.5)' > "$repo/common.sh"
+  git -C "$repo" add pom.xml common.sh
+  git -C "$repo" commit --quiet -m fixture
+  git -C "$repo" tag v1.2.3
+  git -C "$repo" remote add origin "$fork"
+  git -C "$repo" push --quiet origin HEAD 'refs/tags/v1.2.3'
+
+  set +e
+  output="$(CONNECTOR_REPO="$repo" "$SCRIPTS/publish.sh" 3.5 2>&1)"
+  status=$?
+  set -e
+  rm -rf "$work"
+
+  [ "$status" -ne 0 ] \
+    && [[ "$output" == *"origin is not the StarRocks Spark connector repository"* ]]
+}
+
 test_verified_bundle_upload() {
   # shellcheck disable=SC1091
   source "$SCRIPTS/lib.sh"
@@ -322,6 +355,7 @@ assert_success "duplicate Spark versions cannot be selected" test_version_select
 assert_success "custom Maven settings reach deploy.sh" test_custom_maven_settings
 assert_success "Central no-upload rehearsal is pinned to its verified plugin" test_central_dry_run_contract
 assert_success "linked-worktree rejection uses an isolated fixture" test_linked_worktree_rejected
+assert_success "publish rejects a matching tag from a non-official origin" test_publish_rechecks_official_origin
 assert_success "Central API credentials come from Maven settings without logging them" test_central_api_credentials_from_maven_settings
 assert_success "verified Central bundle is uploaded directly" test_verified_bundle_upload
 assert_success "JAR verifier validates Spark release metadata" test_jar_validation

--- a/.claude/skills/spark-connector-release/tests/run_tests.sh
+++ b/.claude/skills/spark-connector-release/tests/run_tests.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# Modifications Copyright 2021 StarRocks Limited.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SKILL_DIR/../../.." && pwd)"
+SCRIPTS="$SKILL_DIR/scripts"
+
+passed=0
+failed=0
+
+pass_test() {
+  printf 'PASS %s\n' "$1"
+  passed=$((passed + 1))
+}
+
+fail_test() {
+  printf 'FAIL %s: %s\n' "$1" "$2" >&2
+  failed=$((failed + 1))
+}
+
+assert_success() {
+  local name="$1"
+  shift
+  if "$@"; then
+    pass_test "$name"
+  else
+    fail_test "$name" "command failed: $*"
+  fi
+}
+
+assert_failure_with() {
+  local name="$1" expected="$2"
+  shift 2
+  local output status
+  set +e
+  output="$("$@" 2>&1)"
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ] && [[ "$output" == *"$expected"* ]]; then
+    pass_test "$name"
+  else
+    fail_test "$name" "expected failure containing '$expected'; status=$status output=$output"
+  fi
+}
+
+make_fake_jar() {
+  local destination="$1" version="$2" spark="$3" scala="$4" commit="$5" class_major="$6" sdk_version="$7"
+  local fixture artifact class_hi class_lo
+  fixture="$(mktemp -d)"
+  artifact="starrocks-spark-connector-${spark}_${scala}"
+  mkdir -p \
+    "$fixture/META-INF/maven/com.starrocks/$artifact" \
+    "$fixture/META-INF/maven/com.starrocks/starrocks-stream-load-sdk" \
+    "$fixture/com/starrocks/connector/spark" \
+    "$fixture/com/starrocks/data/load/stream"
+  printf 'groupId=com.starrocks\nartifactId=%s\nversion=%s\n' "$artifact" "$version" \
+    > "$fixture/META-INF/maven/com.starrocks/$artifact/pom.properties"
+  printf 'git.build.version=%s\ngit.commit.id=%s\n' "$version" "$commit" \
+    > "$fixture/starrocks-spark-connector-git.properties"
+  printf 'groupId=com.starrocks\nartifactId=starrocks-stream-load-sdk\nversion=%s\n' "$sdk_version" \
+    > "$fixture/META-INF/maven/com.starrocks/starrocks-stream-load-sdk/pom.properties"
+  printf 'git.build.version=%s\ngit.commit.id=1111111111111111111111111111111111111111\n' "$sdk_version" \
+    > "$fixture/stream-load-sdk-git.properties"
+  class_hi=$((class_major / 256))
+  class_lo=$((class_major % 256))
+  printf '\xca\xfe\xba\xbe\x00\x00' > "$fixture/com/starrocks/connector/spark/Fixture.class"
+  printf "\\$(printf '%03o' "$class_hi")\\$(printf '%03o' "$class_lo")" \
+    >> "$fixture/com/starrocks/connector/spark/Fixture.class"
+  printf 'sdk' > "$fixture/com/starrocks/data/load/stream/Chunk.class"
+  (cd "$fixture" && zip -qr "$destination" .)
+  rm -rf "$fixture"
+}
+
+test_required_files() {
+  local file
+  for file in \
+    SKILL.md \
+    references/release-guide.md \
+    assets/release-note-template.md \
+    scripts/lib.sh \
+    scripts/preflight.sh \
+    scripts/prepare_release.sh \
+    scripts/build_verify.sh \
+    scripts/publish.sh \
+    scripts/verify_central.sh \
+    scripts/create_github_release.sh \
+    scripts/verify_bundle.sh \
+    scripts/verify_jar.sh; do
+    [ -f "$SKILL_DIR/$file" ] || return 1
+  done
+}
+
+test_scripts_are_executable() {
+  local script
+  for script in "$SCRIPTS"/*.sh; do
+    [ -x "$script" ] || return 1
+  done
+}
+
+test_supported_versions_come_from_common() {
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib.sh"
+  local actual expected
+  actual="$(supported_spark_versions "$REPO_ROOT" | paste -sd ' ' -)"
+  expected="$(CUSTOM_MVN=true bash -c 'source "$1/common.sh" >/dev/null; printf "%s\\n" "${SUPPORTED_SPARK_VERSIONS[@]}"' _ "$REPO_ROOT" | paste -sd ' ' -)"
+  [ "$actual" = "$expected" ] && [ -n "$actual" ]
+}
+
+test_profile_mappings() {
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib.sh"
+  local spark expected_java expected_scala
+  while IFS= read -r spark; do
+    case "$spark" in
+      3.*) expected_java=8; expected_scala=2.12 ;;
+      4.*) expected_java=17; expected_scala=2.13 ;;
+      *) return 1 ;;
+    esac
+    [ "$(spark_java_major "$REPO_ROOT" "$spark")" = "$expected_java" ]
+    [ "$(spark_scala_binary "$REPO_ROOT" "$spark")" = "$expected_scala" ]
+  done < <(supported_spark_versions "$REPO_ROOT")
+}
+
+test_version_selection_guards() {
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib.sh"
+  local spark
+  spark="$(supported_spark_versions "$REPO_ROOT" | head -1)"
+  [ -n "$spark" ]
+  assert_failure_with "duplicate Spark selection is rejected" "selected more than once" \
+    resolve_versions "$REPO_ROOT" "$spark" "$spark"
+}
+
+test_custom_maven_settings() {
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib.sh"
+  local actual
+  actual="$(CUSTOM_MVN='mvn -o' MAVEN_SETTINGS=/tmp/release-settings.xml release_maven_command)"
+  [ "$actual" = 'mvn -o --settings /tmp/release-settings.xml' ]
+}
+
+test_central_dry_run_contract() {
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib.sh"
+  [ "$(central_plugin_version "$REPO_ROOT")" = 0.8.0 ]
+  assert_central_dry_run_contract "$REPO_ROOT"
+}
+
+test_linked_worktree_rejected() {
+  # This repository is intentionally the development linked worktree.
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib.sh"
+  assert_primary_checkout "$REPO_ROOT"
+}
+
+test_jar_validation() {
+  local work commit good wrong_major snapshot_sdk
+  work="$(mktemp -d)"
+  commit=0123456789abcdef0123456789abcdef01234567
+  good="$work/starrocks-spark-connector-3.5_2.12-1.2.0.jar"
+  wrong_major="$work/starrocks-spark-connector-4.1_2.13-1.2.0.jar"
+  snapshot_sdk="$work/starrocks-spark-connector-3.5_2.12-1.2.0.jar.snapshot-sdk"
+  make_fake_jar "$good" 1.2.0 3.5 2.12 "$commit" 52 1.0
+  make_fake_jar "$wrong_major" 1.2.0 4.1 2.13 "$commit" 52 1.0
+  cp "$good" "$snapshot_sdk"
+  fixture="$(mktemp -d)"
+  (cd "$fixture" && unzip -q "$snapshot_sdk")
+  printf 'git.build.version=1.0-SNAPSHOT\ngit.commit.id=1111111111111111111111111111111111111111\n' \
+    > "$fixture/stream-load-sdk-git.properties"
+  (cd "$fixture" && zip -qr "$snapshot_sdk" .)
+  rm -rf "$fixture"
+  "$SCRIPTS/verify_jar.sh" "$good" "$commit" 1.2.0 3.5 2.12 8 1.0 >/dev/null
+  assert_failure_with "jar rejects wrong Java bytecode" "bytecode" \
+    "$SCRIPTS/verify_jar.sh" "$wrong_major" "$commit" 1.2.0 4.1 2.13 17 1.0
+  assert_failure_with "jar rejects snapshot Stream Load SDK metadata" "SDK Git version" \
+    "$SCRIPTS/verify_jar.sh" "$snapshot_sdk" "$commit" 1.2.0 3.5 2.12 8 1.0
+  rm -rf "$work"
+}
+
+test_irreversible_stage_guards() {
+  rg -q --fixed-strings -- '-DskipPublishing=true' "$SCRIPTS/build_verify.sh"
+  rg -q --fixed-strings 'CONFIRM_PUBLISH' "$SCRIPTS/publish.sh"
+  rg -q --fixed-strings 'publishing-$spark.env' "$SCRIPTS/publish.sh"
+  rg -q --fixed-strings -- '--draft' "$SCRIPTS/create_github_release.sh"
+  ! rg -q --fixed-strings -- '--draft=false' "$SCRIPTS/create_github_release.sh"
+}
+
+assert_success "required files exist" test_required_files
+assert_success "release scripts are executable" test_scripts_are_executable
+assert_success "supported versions come from common.sh" test_supported_versions_come_from_common
+assert_success "Spark profiles map to the required JDK and Scala" test_profile_mappings
+assert_success "duplicate Spark versions cannot be selected" test_version_selection_guards
+assert_success "custom Maven settings reach deploy.sh" test_custom_maven_settings
+assert_success "Central no-upload rehearsal is pinned to its verified plugin" test_central_dry_run_contract
+assert_failure_with "linked worktree is rejected" "linked Git worktree" test_linked_worktree_rejected
+assert_success "JAR verifier accepts valid artifact and rejects wrong bytecode" test_jar_validation
+assert_success "publish and GitHub stages retain irreversible-action guards" test_irreversible_stage_guards
+
+for script in "$SCRIPTS"/*.sh "$TEST_DIR"/*.sh; do
+  if bash -n "$script"; then
+    pass_test "bash syntax: $(basename "$script")"
+  else
+    fail_test "bash syntax: $(basename "$script")" "bash -n failed"
+  fi
+done
+
+printf '\n%d passed, %d failed\n' "$passed" "$failed"
+[ "$failed" -eq 0 ]

--- a/.claude/skills/spark-connector-release/tests/run_tests.sh
+++ b/.claude/skills/spark-connector-release/tests/run_tests.sh
@@ -273,14 +273,21 @@ test_central_api_credentials_from_maven_settings() {
 }
 
 test_jar_validation() {
-  local work commit spark3 spark4 snapshot_sdk
+  local work commit spark3 spark4 snapshot_sdk missing_sdk_dir missing_sdk_classes
   work="$(mktemp -d)"
   commit=0123456789abcdef0123456789abcdef01234567
   spark3="$work/starrocks-spark-connector-3.5_2.12-1.2.0.jar"
   spark4="$work/starrocks-spark-connector-4.1_2.13-1.2.0.jar"
   snapshot_sdk="$work/starrocks-spark-connector-3.5_2.12-1.2.0.jar.snapshot-sdk"
+  missing_sdk_dir="$work/missing-sdk-classes"
+  missing_sdk_classes="$missing_sdk_dir/starrocks-spark-connector-3.5_2.12-1.2.0.jar"
   make_fake_jar "$spark3" 1.2.0 3.5 2.12 "$commit" 1.0
   make_fake_jar "$spark4" 1.2.0 4.1 2.13 "$commit" 1.0
+  mkdir -p "$missing_sdk_dir"
+  cp "$spark3" "$missing_sdk_classes"
+  zip -dq "$missing_sdk_classes" 'com/starrocks/data/load/stream/*.class'
+  unzip -Z1 "$missing_sdk_classes" \
+    | rg -Fxq 'com/starrocks/data/load/stream/'
   cp "$spark3" "$snapshot_sdk"
   fixture="$(mktemp -d)"
   (cd "$fixture" && unzip -q "$snapshot_sdk")
@@ -292,6 +299,8 @@ test_jar_validation() {
   "$SCRIPTS/verify_jar.sh" "$spark4" "$commit" 1.2.0 4.1 2.13 1.0 >/dev/null
   assert_failure_with "jar rejects snapshot Stream Load SDK metadata" "SDK Git version" \
     "$SCRIPTS/verify_jar.sh" "$snapshot_sdk" "$commit" 1.2.0 3.5 2.12 1.0
+  assert_failure_with "jar rejects an SDK package without class files" "Stream Load SDK classes are missing" \
+    "$SCRIPTS/verify_jar.sh" "$missing_sdk_classes" "$commit" 1.2.0 3.5 2.12 1.0
   rm -rf "$work"
 }
 

--- a/.claude/skills/spark-connector-release/tests/run_tests.sh
+++ b/.claude/skills/spark-connector-release/tests/run_tests.sh
@@ -64,8 +64,8 @@ assert_failure_with() {
 }
 
 make_fake_jar() {
-  local destination="$1" version="$2" spark="$3" scala="$4" commit="$5" class_major="$6" sdk_version="$7"
-  local fixture artifact class_hi class_lo
+  local destination="$1" version="$2" spark="$3" scala="$4" commit="$5" sdk_version="$6"
+  local fixture artifact
   fixture="$(mktemp -d)"
   artifact="starrocks-spark-connector-${spark}_${scala}"
   mkdir -p \
@@ -81,11 +81,7 @@ make_fake_jar() {
     > "$fixture/META-INF/maven/com.starrocks/starrocks-stream-load-sdk/pom.properties"
   printf 'git.build.version=%s\ngit.commit.id=1111111111111111111111111111111111111111\n' "$sdk_version" \
     > "$fixture/stream-load-sdk-git.properties"
-  class_hi=$((class_major / 256))
-  class_lo=$((class_major % 256))
-  printf '\xca\xfe\xba\xbe\x00\x00' > "$fixture/com/starrocks/connector/spark/Fixture.class"
-  printf "\\$(printf '%03o' "$class_hi")\\$(printf '%03o' "$class_lo")" \
-    >> "$fixture/com/starrocks/connector/spark/Fixture.class"
+  printf 'connector-class' > "$fixture/com/starrocks/connector/spark/Fixture.class"
   printf 'sdk' > "$fixture/com/starrocks/data/load/stream/Chunk.class"
   (cd "$fixture" && zip -qr "$destination" .)
   rm -rf "$fixture"
@@ -174,26 +170,25 @@ test_linked_worktree_rejected() {
 }
 
 test_jar_validation() {
-  local work commit good wrong_major snapshot_sdk
+  local work commit spark3 spark4 snapshot_sdk
   work="$(mktemp -d)"
   commit=0123456789abcdef0123456789abcdef01234567
-  good="$work/starrocks-spark-connector-3.5_2.12-1.2.0.jar"
-  wrong_major="$work/starrocks-spark-connector-4.1_2.13-1.2.0.jar"
+  spark3="$work/starrocks-spark-connector-3.5_2.12-1.2.0.jar"
+  spark4="$work/starrocks-spark-connector-4.1_2.13-1.2.0.jar"
   snapshot_sdk="$work/starrocks-spark-connector-3.5_2.12-1.2.0.jar.snapshot-sdk"
-  make_fake_jar "$good" 1.2.0 3.5 2.12 "$commit" 52 1.0
-  make_fake_jar "$wrong_major" 1.2.0 4.1 2.13 "$commit" 52 1.0
-  cp "$good" "$snapshot_sdk"
+  make_fake_jar "$spark3" 1.2.0 3.5 2.12 "$commit" 1.0
+  make_fake_jar "$spark4" 1.2.0 4.1 2.13 "$commit" 1.0
+  cp "$spark3" "$snapshot_sdk"
   fixture="$(mktemp -d)"
   (cd "$fixture" && unzip -q "$snapshot_sdk")
   printf 'git.build.version=1.0-SNAPSHOT\ngit.commit.id=1111111111111111111111111111111111111111\n' \
     > "$fixture/stream-load-sdk-git.properties"
   (cd "$fixture" && zip -qr "$snapshot_sdk" .)
   rm -rf "$fixture"
-  "$SCRIPTS/verify_jar.sh" "$good" "$commit" 1.2.0 3.5 2.12 8 1.0 >/dev/null
-  assert_failure_with "jar rejects wrong Java bytecode" "bytecode" \
-    "$SCRIPTS/verify_jar.sh" "$wrong_major" "$commit" 1.2.0 4.1 2.13 17 1.0
+  "$SCRIPTS/verify_jar.sh" "$spark3" "$commit" 1.2.0 3.5 2.12 1.0 >/dev/null
+  "$SCRIPTS/verify_jar.sh" "$spark4" "$commit" 1.2.0 4.1 2.13 1.0 >/dev/null
   assert_failure_with "jar rejects snapshot Stream Load SDK metadata" "SDK Git version" \
-    "$SCRIPTS/verify_jar.sh" "$snapshot_sdk" "$commit" 1.2.0 3.5 2.12 8 1.0
+    "$SCRIPTS/verify_jar.sh" "$snapshot_sdk" "$commit" 1.2.0 3.5 2.12 1.0
   rm -rf "$work"
 }
 
@@ -213,7 +208,7 @@ assert_success "duplicate Spark versions cannot be selected" test_version_select
 assert_success "custom Maven settings reach deploy.sh" test_custom_maven_settings
 assert_success "Central no-upload rehearsal is pinned to its verified plugin" test_central_dry_run_contract
 assert_failure_with "linked worktree is rejected" "linked Git worktree" test_linked_worktree_rejected
-assert_success "JAR verifier accepts valid artifact and rejects wrong bytecode" test_jar_validation
+assert_success "JAR verifier validates Spark release metadata" test_jar_validation
 assert_success "publish and GitHub stages retain irreversible-action guards" test_irreversible_stage_guards
 
 for script in "$SCRIPTS"/*.sh "$TEST_DIR"/*.sh; do

--- a/.claude/skills/spark-connector-release/tests/run_tests.sh
+++ b/.claude/skills/spark-connector-release/tests/run_tests.sh
@@ -163,10 +163,113 @@ test_central_dry_run_contract() {
 }
 
 test_linked_worktree_rejected() {
-  # This repository is intentionally the development linked worktree.
   # shellcheck disable=SC1091
   source "$SCRIPTS/lib.sh"
-  assert_primary_checkout "$REPO_ROOT"
+  local fixture_root linked_checkout output status
+  fixture_root="$(mktemp -d)"
+  linked_checkout="$fixture_root/linked-checkout"
+  git -C "$REPO_ROOT" worktree add --quiet --detach "$linked_checkout" HEAD || {
+    rmdir "$fixture_root"
+    return 1
+  }
+
+  set +e
+  output="$(assert_primary_checkout "$linked_checkout" 2>&1)"
+  status=$?
+  set -e
+
+  git -C "$REPO_ROOT" worktree remove --force "$linked_checkout" >/dev/null
+  rmdir "$fixture_root"
+  [ "$status" -ne 0 ] && [[ "$output" == *"linked Git worktree"* ]]
+}
+
+test_verified_bundle_upload() {
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib.sh"
+  local work bundle curl_config call_log marker bundle_sha
+  work="$(mktemp -d)"
+  bundle="$work/verified-central-bundle.zip"
+  curl_config="$work/curl.conf"
+  call_log="$work/curl.log"
+  marker="$work/publishing.env"
+  printf 'verified bundle bytes' > "$bundle"
+  printf 'header = "Authorization: Bearer test"\n' > "$curl_config"
+  printf 'started=yes\n' > "$marker"
+
+  curl() {
+    local output='' argument previous='' url
+    url="${*: -1}"
+    printf '%s\n' "$*" >> "$call_log"
+    for argument in "$@"; do
+      if [ "$previous" = --output ]; then
+        output="$argument"
+      fi
+      previous="$argument"
+    done
+    [ -n "$output" ] || return 2
+    case "$url" in
+      */api/v1/publisher/upload\?*)
+        printf '01234567-89ab-cdef-0123-456789abcdef' > "$output"
+        printf '201'
+        ;;
+      */api/v1/publisher/status\?id=*)
+        printf '{"deploymentState":"PUBLISHED"}\n' > "$output"
+        printf '200'
+        ;;
+      *) return 3 ;;
+    esac
+  }
+
+  if ! publish_verified_bundle "$bundle" 'spark-3.5 release' "$curl_config" "$marker" >/dev/null; then
+    unset -f curl
+    rm -rf "$work"
+    return 1
+  fi
+  bundle_sha="$(sha256sum "$bundle" | awk '{print $1}')"
+  if ! rg -Fxq 'deployment_id=01234567-89ab-cdef-0123-456789abcdef' "$marker" \
+      || ! rg -Fxq "bundle_sha256=$bundle_sha" "$marker" \
+      || ! rg -Fq -- "--form bundle=@$bundle;type=application/octet-stream" "$call_log" \
+      || ! rg -Fq -- 'publishingType=AUTOMATIC' "$call_log" \
+      || ! rg -Fq -- '--connect-timeout 20' "$call_log" \
+      || ! rg -Fq -- '--max-time 600' "$call_log" \
+      || ! rg -Fq -- '--max-time 60' "$call_log"; then
+    unset -f curl
+    rm -rf "$work"
+    return 1
+  fi
+  unset -f curl
+  rm -rf "$work"
+}
+
+test_central_api_credentials_from_maven_settings() {
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib.sh"
+  local work settings curl_config
+  work="$(mktemp -d)"
+  settings="$work/settings.xml"
+  curl_config="$work/curl.conf"
+  printf '%s\n' \
+    '<settings>' \
+    '  <servers>' \
+    '    <server>' \
+    '      <id>central</id>' \
+    '      <username>test-user</username>' \
+    '      <password>test-pass</password>' \
+    '    </server>' \
+    '  </servers>' \
+    '</settings>' > "$settings"
+
+  MAVEN_SETTINGS="$settings" CENTRAL_USERNAME= CENTRAL_PASSWORD= \
+    write_central_curl_config "$curl_config" || {
+      rm -rf "$work"
+      return 1
+    }
+  if [ "$(stat -c '%a' "$curl_config")" != 600 ] \
+      || ! rg -Fxq 'header = "Authorization: Bearer dGVzdC11c2VyOnRlc3QtcGFzcw=="' "$curl_config"; then
+    rm -rf "$work"
+    return 1
+  fi
+  rm -rf "$work"
 }
 
 test_jar_validation() {
@@ -193,11 +296,13 @@ test_jar_validation() {
 }
 
 test_irreversible_stage_guards() {
-  rg -q --fixed-strings -- '-DskipPublishing=true' "$SCRIPTS/build_verify.sh"
-  rg -q --fixed-strings 'CONFIRM_PUBLISH' "$SCRIPTS/publish.sh"
-  rg -q --fixed-strings 'publishing-$spark.env' "$SCRIPTS/publish.sh"
-  rg -q --fixed-strings -- '--draft' "$SCRIPTS/create_github_release.sh"
-  ! rg -q --fixed-strings -- '--draft=false' "$SCRIPTS/create_github_release.sh"
+  rg -q --fixed-strings -- '-DskipPublishing=true' "$SCRIPTS/build_verify.sh" || return 1
+  rg -q --fixed-strings 'CONFIRM_PUBLISH' "$SCRIPTS/publish.sh" || return 1
+  rg -q --fixed-strings 'publishing-$spark.env' "$SCRIPTS/publish.sh" || return 1
+  rg -q --fixed-strings 'publish_verified_bundle' "$SCRIPTS/publish.sh" || return 1
+  ! rg -q --fixed-strings 'bash deploy.sh' "$SCRIPTS/publish.sh" || return 1
+  rg -q --fixed-strings -- '--draft' "$SCRIPTS/create_github_release.sh" || return 1
+  ! rg -q --fixed-strings -- '--draft=false' "$SCRIPTS/create_github_release.sh" || return 1
 }
 
 assert_success "required files exist" test_required_files
@@ -207,7 +312,9 @@ assert_success "Spark profiles map to the required JDK and Scala" test_profile_m
 assert_success "duplicate Spark versions cannot be selected" test_version_selection_guards
 assert_success "custom Maven settings reach deploy.sh" test_custom_maven_settings
 assert_success "Central no-upload rehearsal is pinned to its verified plugin" test_central_dry_run_contract
-assert_failure_with "linked worktree is rejected" "linked Git worktree" test_linked_worktree_rejected
+assert_success "linked-worktree rejection uses an isolated fixture" test_linked_worktree_rejected
+assert_success "Central API credentials come from Maven settings without logging them" test_central_api_credentials_from_maven_settings
+assert_success "verified Central bundle is uploaded directly" test_verified_bundle_upload
 assert_success "JAR verifier validates Spark release metadata" test_jar_validation
 assert_success "publish and GitHub stages retain irreversible-action guards" test_irreversible_stage_guards
 


### PR DESCRIPTION
## What changed

- Add a Spark-specific connector release skill with semantic workflow scripts.
- Read the supported Spark matrix exclusively from `common.sh`.
- Enforce Spark 3.x with Scala 2.12/JDK 8 and Spark 4.x with Scala 2.13/JDK 17.
- Exercise the real `deploy.sh` release lifecycle with `skipPublishing=true`, pinned to the reviewed Central Publishing Maven Plugin 0.8.0 behavior.
- Verify release JAR metadata, Git commit fingerprints, shaded Stream Load SDK metadata/classes, GPG signatures, checksums, and Central bundles.
- Gate immutable Central publication with explicit confirmation and interrupted-publication markers.
- Verify artifacts downloaded from Maven Central before creating a draft GitHub release.

## Why

The connector release matrix spans multiple Spark, Scala, and JDK generations. A repository-local workflow makes those compatibility requirements and irreversible publication checks repeatable while keeping `common.sh` as the source of truth.

## Validation

- `bash .claude/skills/spark-connector-release/tests/run_tests.sh` — 22 passed, 0 failed.
- Skill structure validation passed.
- `bash build.sh 4.1` completed successfully with JDK 17 and Scala 2.13.
- The verifier correctly rejected the SNAPSHOT development JAR and the missing Git fingerprint produced in a linked worktree.
- Apache RAT passed with 0 unapproved files during the Spark 4.1 build.

No Central or GitHub release publication was performed while validating this skill.