### PR TITLE
[Tool] Expose Spark release skill to Codex

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.claude/skills/spark-connector-release/tests/run_tests.sh
+++ b/.claude/skills/spark-connector-release/tests/run_tests.sh
@@ -106,6 +106,16 @@ test_required_files() {
   done
 }
 
+test_codex_project_skill_is_discoverable() {
+  local codex_skills codex_skill
+  codex_skills="$REPO_ROOT/.agents/skills"
+  codex_skill="$REPO_ROOT/.agents/skills/spark-connector-release"
+  [ -L "$codex_skills" ] \
+    && [ "$(readlink "$codex_skills")" = '../.claude/skills' ] \
+    && [ -f "$codex_skill/SKILL.md" ] \
+    && [ "$codex_skill/SKILL.md" -ef "$SKILL_DIR/SKILL.md" ]
+}
+
 test_scripts_are_executable() {
   local script
   for script in "$SCRIPTS"/*.sh; do
@@ -348,6 +358,7 @@ test_irreversible_stage_guards() {
 }
 
 assert_success "required files exist" test_required_files
+assert_success "Codex discovers the project skill from .agents/skills" test_codex_project_skill_is_discoverable
 assert_success "release scripts are executable" test_scripts_are_executable
 assert_success "supported versions come from common.sh" test_supported_versions_come_from_common
 assert_success "Spark profiles map to the required JDK and Scala" test_profile_mappings


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

## Which issues of this PR fixes ：

N/A

## Problem Summary(Required) ：

PR #165 added the Spark connector release skill only under `.claude/skills`. Fresh Codex sessions discover repository-local skills through `.agents/skills`, so Codex could not load the merged skill.

Add the portable relative symlink `.agents/skills -> ../.claude/skills`. This keeps `.claude/skills` as the single canonical copy while exposing the same skill to Codex. Add a regression test that verifies the Codex entry is a relative symlink and resolves to the canonical `SKILL.md`.

Validation:
- Release skill test suite: 27 passed, 0 failed.
- Skill validator passes through both `.claude/skills` and `.agents/skills`.
- Fresh ephemeral Codex 0.146.0 discovered `spark-connector-release`.
- An absolute-symlink mutation was rejected by the regression test.
- Independent code review: Ready to merge.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function