### PR TITLE
[Tool] Validate release version documentation

### DIFF
--- a/.claude/skills/spark-connector-release/SKILL.md
+++ b/.claude/skills/spark-connector-release/SKILL.md
@@ -25,6 +25,9 @@ artifacts after publication.
   exists only in `pom.xml` is not releasable unless `common.sh` lists it.
 - Use JDK 8 for Spark 3.x and JDK 17 for Spark 4.x. The scripts verify the active JDK and
   the profile's Java source/target configuration.
+- Before creating the release branch, require an exact release-version row in both user-doc
+  `Version requirements` tables. If either row is missing, stop and get the user's explicit
+  approval; never set `CONFIRM_DOCS_VERSION` based on the agent's own judgment.
 - Stop on any non-zero script result. Never bypass the verification marker or publication
   confirmation.
 - Never attempt to overwrite or redeploy coordinates already published to Maven Central.
@@ -65,9 +68,16 @@ discovered runtime reports the exact required major version.
 
 ### Prepare the release commit and local tag
 
-`prepare_release.sh <version>` fetches `origin/main`, creates `release-<version>`, sets
-the top-level Maven version, commits it, and creates local tag `v<version>`. It refuses to
-reuse a local or remote branch/tag and does not push anything.
+`prepare_release.sh <version>` fetches `origin/main` and first checks that its
+`docs/connector-read.md` and `docs/connector-write.md` `Version requirements` tables both
+contain an exact row for the requested version, including RC versions. A missing row always
+requires the user's explicit confirmation: interactively answer the prompt, or only after
+the user agrees, relay that decision with `CONFIRM_DOCS_VERSION=<version>` in a
+non-interactive run.
+
+The script then creates `release-<version>`, sets the top-level Maven version, commits it,
+and creates local tag `v<version>`. It refuses to reuse a local or remote branch/tag and
+does not push anything.
 
 ### Build and verify without publishing
 

--- a/.claude/skills/spark-connector-release/references/release-guide.md
+++ b/.claude/skills/spark-connector-release/references/release-guide.md
@@ -42,6 +42,18 @@ version in this project does not correctly generate `starrocks-spark-connector-g
 from a linked worktree. Maven can still report success in that situation, leaving a JAR that
 cannot be tied back to its release tag. The preflight rejects linked worktrees explicitly.
 
+## Version requirements documentation
+
+Before creating a release branch, `prepare_release.sh` checks the fetched `origin/main`
+versions of `docs/connector-read.md` and `docs/connector-write.md`. The first cell of a row
+inside each document's `Version requirements` section must exactly equal the requested
+connector version. Prefix matches and mentions elsewhere in the document do not count.
+
+If either row is missing, the release can continue only after the user explicitly approves
+the omission, including for RC versions. In a non-interactive run,
+`CONFIRM_DOCS_VERSION=<version>` relays that prior user decision; an agent must never set it
+without asking the user.
+
 ## Central Publisher Portal credentials
 
 The POM uses `org.sonatype.central:central-publishing-maven-plugin` with server id `central`
@@ -111,13 +123,14 @@ publication.
 
 Maven Central coordinates are immutable. The safe order is:
 
-1. create a release commit and local tag;
-2. build all signed bundles from that exact commit without uploading;
-3. inspect the real JAR metadata, signatures, checksums, and required shaded classes;
-4. push the verified tag;
-5. upload that exact verified bundle with explicit confirmation;
-6. download and verify what Maven Central serves;
-7. create a draft GitHub release from the verified public JARs.
+1. verify that both user-doc version tables list the release, or explicitly approve the omission;
+2. create a release commit and local tag;
+3. build all signed bundles from that exact commit without uploading;
+4. inspect the real JAR metadata, signatures, checksums, and required shaded classes;
+5. push the verified tag;
+6. upload that exact verified bundle with explicit confirmation;
+7. download and verify what Maven Central serves;
+8. create a draft GitHub release from the verified public JARs.
 
 ## Failure recovery
 
@@ -125,6 +138,7 @@ Maven Central coordinates are immutable. The safe order is:
 | --- | --- |
 | A JDK cannot be found | Set `JAVA8_HOME` or `JAVA17_HOME` to the required installation. |
 | Preflight reports a linked worktree | Use a primary clone/checkout for the release. |
+| A user-doc version row is missing | Add the exact row on `main`, or ask the user whether to continue without it. |
 | Connector Git properties are missing | Do not publish; confirm the checkout type and rebuild. |
 | GPG signing fails | Check the secret key, passphrase source, loopback support, and `gpg-agent`. |
 | Central authentication fails | Regenerate/check the Portal token and namespace permission. |

--- a/.claude/skills/spark-connector-release/scripts/lib.sh
+++ b/.claude/skills/spark-connector-release/scripts/lib.sh
@@ -71,6 +71,62 @@ pom_is_snapshot() {
   [[ "$(pom_connector_version "$1")" == *-SNAPSHOT ]]
 }
 
+DOCS_VERSION_FILES=(docs/connector-read.md docs/connector-write.md)
+
+version_row_in_stream() {
+  local version="$1"
+  awk -v v="$version" -F'|' '
+    /^##[[:space:]]+Version requirements/ { in_section = 1; next }
+    in_section && /^##[[:space:]]/ { in_section = 0 }
+    in_section && $1 == "" && NF >= 2 {
+      cell = $2
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", cell)
+      if (cell == v) found = 1
+    }
+    END { exit found ? 0 : 1 }
+  '
+}
+
+docs_version_row_exists() {
+  local root="$1" version="$2" file="$3" ref="${4:-}"
+  if [ -n "$ref" ]; then
+    git -C "$root" show "$ref:$file" 2>/dev/null | version_row_in_stream "$version"
+  else
+    [ -f "$root/$file" ] && version_row_in_stream "$version" < "$root/$file"
+  fi
+}
+
+check_docs_version() {
+  local root="$1" version="$2" ref="${3:-}" file answer source_label
+  local -a missing=()
+  source_label="${ref:-working tree}"
+
+  for file in "${DOCS_VERSION_FILES[@]}"; do
+    if docs_version_row_exists "$root" "$version" "$file" "$ref"; then
+      pass "docs: $source_label:$file lists $version"
+    else
+      missing+=("$file")
+    fi
+  done
+
+  [ "${#missing[@]}" -eq 0 ] && return 0
+
+  warn "$source_label Version requirements table does NOT list $version in: ${missing[*]}"
+  warn "Usually add an exact '$version' row to both documents on main before releasing."
+  if [ -t 0 ]; then
+    printf 'Release %s anyway, without every docs version row? [y/N] ' "$version"
+    read -r answer
+    case "$answer" in
+      y|Y) warn "proceeding without every docs version row for $version (confirmed by user)" ;;
+      *) die "aborted — add the $version rows on main, then rerun" ;;
+    esac
+  else
+    [ "${CONFIRM_DOCS_VERSION:-}" = "$version" ] \
+      || die "non-interactive: docs are missing the exact $version row — ASK THE USER whether to release without it. Only after they explicitly agree, rerun with CONFIRM_DOCS_VERSION=$version; never set it on the agent's own judgment."
+    warn "proceeding without every docs version row for $version (user confirmation relayed by CONFIRM_DOCS_VERSION)"
+  fi
+}
+
 pom_root_property() {
   local root="$1" property="$2"
   awk -v property="$property" '

--- a/.claude/skills/spark-connector-release/scripts/prepare_release.sh
+++ b/.claude/skills/spark-connector-release/scripts/prepare_release.sh
@@ -64,6 +64,8 @@ current="$(git show origin/main:pom.xml | awk '
 [[ "$current" == *-SNAPSHOT ]] \
   || die "origin/main version $current is not a SNAPSHOT; inspect repository state before releasing"
 
+check_docs_version "$REPO_ROOT" "$VERSION" origin/main
+
 info "Creating $BRANCH from origin/main"
 git switch --create "$BRANCH" origin/main
 

--- a/.claude/skills/spark-connector-release/tests/run_tests.sh
+++ b/.claude/skills/spark-connector-release/tests/run_tests.sh
@@ -172,6 +172,117 @@ test_central_dry_run_contract() {
   assert_central_dry_run_contract "$REPO_ROOT"
 }
 
+write_version_doc() {
+  local destination="$1" version="$2"
+  mkdir -p "$(dirname "$destination")"
+  printf '%s\n' \
+    '# Connector documentation' \
+    '' \
+    'This prose mentions 9.9.9 but is not a compatibility declaration.' \
+    '' \
+    '## Version requirements' \
+    '' \
+    '| Spark connector | Spark | Java | Scala |' \
+    '|-----------------|-------|------|-------|' \
+    "| $version | 3.5 | 8 | 2.12 |" \
+    '' \
+    '## Usage' \
+    > "$destination"
+}
+
+test_docs_version_gate_accepts_exact_rows() {
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib.sh"
+  local work
+  work="$(mktemp -d)"
+  write_version_doc "$work/docs/connector-read.md" 1.1.4-RC0
+  write_version_doc "$work/docs/connector-write.md" 1.1.4-RC0
+  if ! check_docs_version "$work" 1.1.4-RC0 >/dev/null; then
+    rm -rf "$work"
+    return 1
+  fi
+  rm -rf "$work"
+}
+
+test_docs_version_gate_requires_exact_confirmation() {
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib.sh"
+  local work output status
+  work="$(mktemp -d)"
+  write_version_doc "$work/docs/connector-read.md" 1.1.4
+  write_version_doc "$work/docs/connector-write.md" 1.1.4
+
+  set +e
+  output="$(CONFIRM_DOCS_VERSION=1.1.4 check_docs_version "$work" 1.1.4-RC0 2>&1)"
+  status=$?
+  set -e
+  rm -rf "$work"
+
+  [ "$status" -ne 0 ] && [[ "$output" == *"ASK THE USER"* ]]
+}
+
+test_docs_version_gate_accepts_user_confirmation() {
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib.sh"
+  local work
+  work="$(mktemp -d)"
+  write_version_doc "$work/docs/connector-read.md" 1.1.4
+  write_version_doc "$work/docs/connector-write.md" 1.1.4
+  if ! CONFIRM_DOCS_VERSION=1.1.4-RC0 \
+      check_docs_version "$work" 1.1.4-RC0 >/dev/null 2>&1; then
+    rm -rf "$work"
+    return 1
+  fi
+  rm -rf "$work"
+}
+
+test_prepare_release_checks_origin_main_docs_before_branching() {
+  local work origin repo fake_bin output status
+  work="$(mktemp -d)"
+  origin="$work/origin.git"
+  repo="$work/repo"
+  fake_bin="$work/bin"
+  git init --quiet --bare "$origin"
+  git init --quiet --initial-branch=main "$repo"
+  git -C "$repo" config user.name 'Release Test'
+  git -C "$repo" config user.email 'release-test@example.com'
+  printf '%s\n' \
+    '<project>' \
+    '  <artifactId>starrocks-spark-connector-${env.SPARK_FEATURE_VERSION}_${env.STARROCKS_SCALA_VERSION}</artifactId>' \
+    '  <version>1.2.3-SNAPSHOT</version>' \
+    '</project>' > "$repo/pom.xml"
+  printf '%s\n' 'SUPPORTED_SPARK_VERSIONS=(3.5)' > "$repo/common.sh"
+  write_version_doc "$repo/docs/connector-read.md" 1.2.2
+  write_version_doc "$repo/docs/connector-write.md" 1.2.2
+  git -C "$repo" add pom.xml common.sh docs
+  git -C "$repo" commit --quiet -m fixture
+  git -C "$repo" remote add origin "$origin"
+  git -C "$repo" push --quiet --set-upstream origin main
+  git -C "$repo" switch --quiet --create local-docs
+  write_version_doc "$repo/docs/connector-read.md" 1.2.3
+  write_version_doc "$repo/docs/connector-write.md" 1.2.3
+  git -C "$repo" add docs
+  git -C "$repo" commit --quiet -m 'local docs only'
+  mkdir -p "$fake_bin"
+  printf '%s\n' '#!/usr/bin/env bash' 'echo "mvn must not run before the docs gate" >&2' 'exit 99' \
+    > "$fake_bin/mvn"
+  chmod +x "$fake_bin/mvn"
+
+  set +e
+  output="$(PATH="$fake_bin:$PATH" CONFIRM_DOCS_VERSION= CONNECTOR_REPO="$repo" \
+    "$SCRIPTS/prepare_release.sh" 1.2.3 2>&1)"
+  status=$?
+  set -e
+
+  if [ "$status" -eq 0 ] \
+      || [[ "$output" != *"ASK THE USER"* ]] \
+      || git -C "$repo" show-ref --verify --quiet refs/heads/release-1.2.3; then
+    rm -rf "$work"
+    return 1
+  fi
+  rm -rf "$work"
+}
+
 test_linked_worktree_rejected() {
   # shellcheck disable=SC1091
   source "$SCRIPTS/lib.sh"
@@ -365,6 +476,10 @@ assert_success "Spark profiles map to the required JDK and Scala" test_profile_m
 assert_success "duplicate Spark versions cannot be selected" test_version_selection_guards
 assert_success "custom Maven settings reach deploy.sh" test_custom_maven_settings
 assert_success "Central no-upload rehearsal is pinned to its verified plugin" test_central_dry_run_contract
+assert_success "docs gate accepts exact version rows" test_docs_version_gate_accepts_exact_rows
+assert_success "docs gate requires confirmation for an exact missing version" test_docs_version_gate_requires_exact_confirmation
+assert_success "docs gate accepts the user's version-scoped confirmation" test_docs_version_gate_accepts_user_confirmation
+assert_success "prepare release checks origin/main docs before creating a branch" test_prepare_release_checks_origin_main_docs_before_branching
 assert_success "linked-worktree rejection uses an isolated fixture" test_linked_worktree_rejected
 assert_success "publish rejects a matching tag from a non-official origin" test_publish_rechecks_official_origin
 assert_success "Central API credentials come from Maven settings without logging them" test_central_api_credentials_from_maven_settings


### PR DESCRIPTION
## Summary

- check the fetched `origin/main` copies of both Spark connector `Version requirements` tables before creating a release branch
- require an exact connector-version row, including RC versions, or explicit user approval to continue
- document the gate and add behavior tests for exact matching, version-scoped confirmation, and `origin/main` isolation

## Why

The Spark release skill could previously create a release branch and tag even when the released connector version was absent from the user documentation. This could leave a published release undocumented.

## Validation

- `bash .claude/skills/spark-connector-release/tests/run_tests.sh` — 31 passed, 0 failed
- skill validation through both `.claude/skills` and `.agents/skills`
- `git diff --check`