### PR TITLE
[BugFix] Fix Spark 4.1 packaging and add real-cluster CI

### DIFF
--- a/.claude/skills/spark-connector-release/SKILL.md
+++ b/.claude/skills/spark-connector-release/SKILL.md
@@ -95,8 +95,7 @@ validation checks:
 - no connector `SNAPSHOT` version;
 - embedded connector commit equals the release-tag commit;
 - Spark/Scala artifact suffixes match the selected profile;
-- connector-owned classes are present in the shaded JAR;
-- the released Stream Load SDK version and its shaded classes/metadata are present;
+- the released Stream Load SDK version and metadata are present;
 - the bundle contains the primary JAR, sources, Javadocs, POM, GPG signatures, and all
   configured checksums, and each signature/checksum verifies locally.
 

--- a/.claude/skills/spark-connector-release/scripts/verify_jar.sh
+++ b/.claude/skills/spark-connector-release/scripts/verify_jar.sh
@@ -121,24 +121,6 @@ else
   no "$SDK_GIT_PROPERTIES is missing"
 fi
 
-sdk_class_list="$(printf '%s\n' "$LIST" \
-  | awk '/^com\/starrocks\/data\/load\/stream\/.*\.class$/')"
-if [ -z "$sdk_class_list" ]; then
-  no "Stream Load SDK classes are missing"
-else
-  sdk_class_count="$(printf '%s\n' "$sdk_class_list" \
-    | awk 'NF { count++ } END { print count + 0 }')"
-  yes "$sdk_class_count Stream Load SDK class files are shaded"
-fi
-
-class_list="$(printf '%s\n' "$LIST" | awk '/^com\/starrocks\/connector\/spark\/.*\.class$/')"
-if [ -z "$class_list" ]; then
-  no "no connector-owned class files found"
-else
-  class_count="$(printf '%s\n' "$class_list" | awk 'NF { count++ } END { print count + 0 }')"
-  yes "$class_count connector-owned class files are present"
-fi
-
 echo
 if [ "$bad" -eq 0 ]; then
   info "${C_GREEN}ALL $ok CHECKS PASSED${C_RESET} — $(basename "$JAR")"

--- a/.claude/skills/spark-connector-release/tests/run_tests.sh
+++ b/.claude/skills/spark-connector-release/tests/run_tests.sh
@@ -70,9 +70,7 @@ make_fake_jar() {
   artifact="starrocks-spark-connector-${spark}_${scala}"
   mkdir -p \
     "$fixture/META-INF/maven/com.starrocks/$artifact" \
-    "$fixture/META-INF/maven/com.starrocks/starrocks-stream-load-sdk" \
-    "$fixture/com/starrocks/connector/spark" \
-    "$fixture/com/starrocks/data/load/stream"
+    "$fixture/META-INF/maven/com.starrocks/starrocks-stream-load-sdk"
   printf 'groupId=com.starrocks\nartifactId=%s\nversion=%s\n' "$artifact" "$version" \
     > "$fixture/META-INF/maven/com.starrocks/$artifact/pom.properties"
   printf 'git.build.version=%s\ngit.commit.id=%s\n' "$version" "$commit" \
@@ -81,8 +79,6 @@ make_fake_jar() {
     > "$fixture/META-INF/maven/com.starrocks/starrocks-stream-load-sdk/pom.properties"
   printf 'git.build.version=%s\ngit.commit.id=1111111111111111111111111111111111111111\n' "$sdk_version" \
     > "$fixture/stream-load-sdk-git.properties"
-  printf 'connector-class' > "$fixture/com/starrocks/connector/spark/Fixture.class"
-  printf 'sdk' > "$fixture/com/starrocks/data/load/stream/Chunk.class"
   (cd "$fixture" && zip -qr "$destination" .)
   rm -rf "$fixture"
 }
@@ -427,21 +423,14 @@ test_central_api_credentials_from_maven_settings() {
 }
 
 test_jar_validation() {
-  local work commit spark3 spark4 snapshot_sdk missing_sdk_dir missing_sdk_classes
+  local work commit spark3 spark4 snapshot_sdk fixture
   work="$(mktemp -d)"
   commit=0123456789abcdef0123456789abcdef01234567
   spark3="$work/starrocks-spark-connector-3.5_2.12-1.2.0.jar"
   spark4="$work/starrocks-spark-connector-4.1_2.13-1.2.0.jar"
   snapshot_sdk="$work/starrocks-spark-connector-3.5_2.12-1.2.0.jar.snapshot-sdk"
-  missing_sdk_dir="$work/missing-sdk-classes"
-  missing_sdk_classes="$missing_sdk_dir/starrocks-spark-connector-3.5_2.12-1.2.0.jar"
   make_fake_jar "$spark3" 1.2.0 3.5 2.12 "$commit" 1.0
   make_fake_jar "$spark4" 1.2.0 4.1 2.13 "$commit" 1.0
-  mkdir -p "$missing_sdk_dir"
-  cp "$spark3" "$missing_sdk_classes"
-  zip -dq "$missing_sdk_classes" 'com/starrocks/data/load/stream/*.class'
-  unzip -Z1 "$missing_sdk_classes" \
-    | rg -Fxq 'com/starrocks/data/load/stream/'
   cp "$spark3" "$snapshot_sdk"
   fixture="$(mktemp -d)"
   (cd "$fixture" && unzip -q "$snapshot_sdk")
@@ -453,8 +442,6 @@ test_jar_validation() {
   "$SCRIPTS/verify_jar.sh" "$spark4" "$commit" 1.2.0 4.1 2.13 1.0 >/dev/null
   assert_failure_with "jar rejects snapshot Stream Load SDK metadata" "SDK Git version" \
     "$SCRIPTS/verify_jar.sh" "$snapshot_sdk" "$commit" 1.2.0 3.5 2.12 1.0
-  assert_failure_with "jar rejects an SDK package without class files" "Stream Load SDK classes are missing" \
-    "$SCRIPTS/verify_jar.sh" "$missing_sdk_classes" "$commit" 1.2.0 3.5 2.12 1.0
   rm -rf "$work"
 }
 

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -20,45 +20,61 @@ name: CI Pipeline
 
 on:
   pull_request:
-      types:
-        - opened
-        - synchronize
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    branches:
+      - main
+  workflow_dispatch:
 
-      branches:
-        - main
+permissions:
+  contents: read
 
 concurrency:
-  group: ${{ github.event.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
     name: Spark ${{ matrix.spark }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
-      fail-fast: true
+      fail-fast: false
       max-parallel: 5
       matrix:
         include:
           - spark: '3.3'
+            full-version: '3.3.2'
+            scala: '2.12'
             java: '8'
           - spark: '3.4'
+            full-version: '3.4.0'
+            scala: '2.12'
             java: '8'
           - spark: '3.5'
+            full-version: '3.5.0'
+            scala: '2.12'
             java: '8'
           - spark: '4.0'
+            full-version: '4.0.0'
+            scala: '2.13'
             java: '17'
           - spark: '4.1'
+            full-version: '4.1.0'
+            scala: '2.13'
             java: '17'
     env:
       CUSTOM_MVN: mvn -B -ntp
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
@@ -75,8 +91,21 @@ jobs:
       - name: Docker Info
         shell: bash
         run: |
-          docker info || true
+          docker info
       - name: Build Spark ${{ matrix.spark }} Connector
         run: |
           chmod +x build.sh
           ./build.sh ${{ matrix.spark }} --run-tests
+      - name: Test packaged connector on Spark ${{ matrix.full-version }} standalone
+        env:
+          SMOKE_LOG_DIR: ${{ runner.temp }}/spark-connector-smoke-${{ matrix.spark }}
+        run: |
+          ./ci/real-cluster/run.sh "${{ matrix.spark }}"
+      - name: Upload Spark ${{ matrix.spark }} cluster diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: spark-${{ matrix.spark }}-real-cluster-logs
+          path: ${{ runner.temp }}/spark-connector-smoke-${{ matrix.spark }}
+          if-no-files-found: warn
+          retention-days: 7

--- a/ci/real-cluster/lib.sh
+++ b/ci/real-cluster/lib.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ci_error() {
+  printf 'ERROR %s\n' "$*" >&2
+}
+
+spark_full_version() {
+  case "${1:-}" in
+    3.3) printf '3.3.2\n' ;;
+    3.4) printf '3.4.0\n' ;;
+    3.5) printf '3.5.0\n' ;;
+    4.0) printf '4.0.0\n' ;;
+    4.1) printf '4.1.0\n' ;;
+    *)
+      ci_error "unsupported Spark minor: ${1:-<empty>}"
+      return 1
+      ;;
+  esac
+}
+
+spark_scala_binary() {
+  case "${1:-}" in
+    3.3|3.4|3.5) printf '2.12\n' ;;
+    4.0|4.1) printf '2.13\n' ;;
+    *)
+      ci_error "unsupported Spark minor: ${1:-<empty>}"
+      return 1
+      ;;
+  esac
+}
+
+spark_build_java_major() {
+  case "${1:-}" in
+    3.3|3.4|3.5) printf '8\n' ;;
+    4.0|4.1) printf '17\n' ;;
+    *)
+      ci_error "unsupported Spark minor: ${1:-<empty>}"
+      return 1
+      ;;
+  esac
+}
+
+spark_runtime_java_major() {
+  case "${1:-}" in
+    3.3|3.4|3.5) printf '11\n' ;;
+    4.0|4.1) printf '17\n' ;;
+    *)
+      ci_error "unsupported Spark minor: ${1:-<empty>}"
+      return 1
+      ;;
+  esac
+}
+
+spark_official_image() {
+  case "${1:-}" in
+    3.3)
+      printf '%s\n' \
+        'apache/spark-py:v3.3.2@sha256:5bb83c62a12546bc0abd5196df301ec64085aa5c38cc9e144c6135d740596c7a'
+      ;;
+    3.4)
+      printf '%s\n' \
+        'apache/spark:3.4.0@sha256:55e67077c859e14b6ea5600dc9dfd67219054c6feed0689558ff07bb4b2c9579'
+      ;;
+    3.5)
+      printf '%s\n' \
+        'apache/spark:3.5.0@sha256:0ed5154e6b32ac3af1272d4d65e9f65b13afcfe80b41ad10bd059bcd6317863c'
+      ;;
+    4.0)
+      printf '%s\n' \
+        'apache/spark:4.0.0@sha256:a89782d90529a623fc4471cdddb0f9c32d6eed10a81b256a80207b23c3b1df00'
+      ;;
+    4.1)
+      printf '%s\n' \
+        'apache/spark:4.1.0-scala2.13-java17-python3-ubuntu@sha256:deaccd823f4bb2b6ed48443abd1ab35669bf9d6c226cf17098d6203182797252'
+      ;;
+    *)
+      ci_error "unsupported Spark minor: ${1:-<empty>}"
+      return 1
+      ;;
+  esac
+}
+
+first_line() {
+  local value="${1:-}"
+  printf '%s\n' "${value%%$'\n'*}"
+}
+
+java_output_matches_major() {
+  local expected_major="${1:-}" output="${2:-}" version_line
+  version_line="$(first_line "$output")"
+  case "$expected_major:$version_line" in
+    8:*'"1.8.'*) ;;
+    11:*'"11.'*) ;;
+    17:*'"17.'*) ;;
+    *) return 1 ;;
+  esac
+}
+
+spark_output_matches_version() {
+  local expected_version="${1:-}" output="${2:-}"
+  [ -n "$expected_version" ] \
+    && printf '%s\n' "$output" | grep -Fq "version $expected_version"
+}
+
+retry_command() {
+  local max_attempts="${1:-}" delay_seconds="${2:-}" attempt=1
+  shift 2
+  [ "$max_attempts" -gt 0 ] 2>/dev/null && [ "$#" -gt 0 ] || {
+    ci_error "usage: retry_command <attempts> <delay-seconds> <command> [args...]"
+    return 1
+  }
+
+  while ! "$@"; do
+    if [ "$attempt" -ge "$max_attempts" ]; then
+      return 1
+    fi
+    ci_error "command failed on attempt $attempt/$max_attempts; retrying"
+    attempt=$((attempt + 1))
+    sleep "$delay_seconds"
+  done
+}
+
+find_mysql_jar() {
+  local maven_repo="${1:-}" expected
+  [ -n "$maven_repo" ] || {
+    ci_error "usage: find_mysql_jar <maven-repository>"
+    return 1
+  }
+  expected="$maven_repo/com/mysql/mysql-connector-j/8.0.33/mysql-connector-j-8.0.33.jar"
+  [ -f "$expected" ] || {
+    ci_error "MySQL connector JAR is missing: $expected"
+    return 1
+  }
+  printf '%s\n' "$expected"
+}
+
+spark_worker_is_alive() {
+  local status_file="${1:-}"
+  [ -f "$status_file" ] || return 1
+  grep -Eq '"state"[[:space:]]*:[[:space:]]*"ALIVE"' "$status_file"
+}
+
+executor_evidence_uses_host() {
+  local application_log="${1:-}" expected_host="${2:-}" line evidence entry
+  local -a entries=()
+  [ -f "$application_log" ] && [ -n "$expected_host" ] || return 1
+  line="$(grep -F 'CHECK distributed_execution PASS ' "$application_log" | tail -1)"
+  [ -n "$line" ] || return 1
+  evidence="${line#*CHECK distributed_execution PASS }"
+  IFS=',' read -r -a entries <<< "$evidence"
+  [ "${#entries[@]}" -gt 0 ] || return 1
+  for entry in "${entries[@]}"; do
+    [[ "$entry" == *"@$expected_host:"* ]] || return 1
+  done
+}
+
+starrocks_backend_is_alive() {
+  local status_file="${1:-}"
+  [ -f "$status_file" ] || return 1
+  awk -F '\t' '
+    NR == 1 {
+      for (column = 1; column <= NF; column++) {
+        if ($column == "Alive") {
+          alive_column = column
+        }
+      }
+      next
+    }
+    alive_column && tolower($alive_column) == "true" { found = 1 }
+    END { exit !found }
+  ' "$status_file"
+}
+
+http_response_is_ready() {
+  [[ "${1:-}" =~ ^[1-5][0-9][0-9]$ ]]
+}
+
+find_connector_jar() {
+  local root="${1:-}" spark="${2:-}" scala="${3:-}"
+  local target candidate basename candidate_count=0 selected=""
+
+  [ -n "$root" ] && [ -n "$spark" ] && [ -n "$scala" ] || {
+    ci_error "usage: find_connector_jar <repo-root> <spark-minor> <scala-binary>"
+    return 1
+  }
+  target="$root/target"
+  [ -d "$target" ] || {
+    ci_error "connector target directory does not exist: $target"
+    return 1
+  }
+
+  while IFS= read -r candidate; do
+    [ -n "$candidate" ] || continue
+    basename="$(basename "$candidate")"
+    case "$basename" in
+      original-*|*-sources.jar|*-javadoc.jar) continue ;;
+    esac
+    candidate_count=$((candidate_count + 1))
+    selected="$candidate"
+  done < <(find "$target" -maxdepth 1 -type f \
+    -name "starrocks-spark-connector-${spark}_${scala}-*.jar" -print | sort)
+
+  if [ "$candidate_count" -ne 1 ]; then
+    ci_error "expected exactly one final Spark $spark / Scala $scala connector JAR in $target, found $candidate_count"
+    return 1
+  fi
+
+  printf '%s\n' "$selected"
+}
+
+verify_connector_jar() {
+  local jar="${1:-}" spark="${2:-}" scala="${3:-}"
+  local artifact basename entries required entry
+
+  [ -f "$jar" ] || {
+    ci_error "connector JAR does not exist: ${jar:-<empty>}"
+    return 1
+  }
+  artifact="starrocks-spark-connector-${spark}_${scala}"
+  basename="$(basename "$jar")"
+  case "$basename" in
+    "$artifact"-*.jar) ;;
+    *)
+      ci_error "$basename is not a final $artifact JAR"
+      return 1
+      ;;
+  esac
+  case "$basename" in
+    original-*|*-sources.jar|*-javadoc.jar)
+      ci_error "$basename is not a final connector JAR"
+      return 1
+      ;;
+  esac
+
+  entries="$(jar tf "$jar")" || {
+    ci_error "cannot read connector JAR: $jar"
+    return 1
+  }
+
+  required="com/starrocks/connector/spark/sql/StarRocksDataSourceProvider.class
+META-INF/maven/com.starrocks/$artifact/pom.properties"
+  while IFS= read -r entry; do
+    if ! grep -Fxq "$entry" <<< "$entries"; then
+      ci_error "Spark $spark connector is missing required entry: $entry"
+      return 1
+    fi
+  done <<< "$required"
+
+  if grep -Eq '^(org/apache/spark|scala)/.*\.class$' <<< "$entries"; then
+    ci_error "Spark $spark connector unexpectedly bundles Spark or Scala implementation classes"
+    return 1
+  fi
+
+  printf 'Verified packaged connector: %s (Spark %s / Scala %s)\n' "$basename" "$spark" "$scala"
+}
+
+package_smoke_jar() {
+  local root="${1:-}" output="${2:-}" classes_root class relative output_dir
+  local -a smoke_classes=()
+
+  [ -n "$root" ] && [ -n "$output" ] || {
+    ci_error "usage: package_smoke_jar <repo-root> <output-jar>"
+    return 1
+  }
+  classes_root="$root/target/test-classes"
+  [ -d "$classes_root" ] || {
+    ci_error "compiled test class directory does not exist: $classes_root"
+    return 1
+  }
+
+  while IFS= read -r -d '' class; do
+    relative="${class#"$classes_root"/}"
+    smoke_classes+=("$relative")
+  done < <(find "$classes_root/com/starrocks/connector/spark/ci" -maxdepth 1 \
+    -type f -name 'ConnectorDocsSmoke*.class' -print0 2>/dev/null | sort -z)
+
+  if [ "${#smoke_classes[@]}" -eq 0 ]; then
+    ci_error "no compiled ConnectorDocsSmoke classes were found below $classes_root"
+    return 1
+  fi
+
+  mkdir -p "$(dirname "$output")"
+  output_dir="$(cd "$(dirname "$output")" && pwd -P)"
+  output="$output_dir/$(basename "$output")"
+  (cd "$classes_root" && jar cf "$output" "${smoke_classes[@]}") || {
+    ci_error "failed to package smoke application JAR: $output"
+    return 1
+  }
+
+  printf '%s\n' "$output"
+}

--- a/ci/real-cluster/run.sh
+++ b/ci/real-cluster/run.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/spark-containers.sh"
+
+if [ "$#" -ne 1 ]; then
+  ci_error "usage: $0 <spark-minor>"
+  exit 1
+fi
+
+SPARK_MINOR="$1"
+SPARK_FULL_VERSION="$(spark_full_version "$SPARK_MINOR")"
+SCALA_BINARY="$(spark_scala_binary "$SPARK_MINOR")"
+EXPECTED_BUILD_JAVA="$(spark_build_java_major "$SPARK_MINOR")"
+EXPECTED_RUNTIME_JAVA="$(spark_runtime_java_major "$SPARK_MINOR")"
+
+MAVEN_REPO="${MAVEN_REPO:-${HOME}/.m2/repository}"
+SMOKE_LOG_DIR="${SMOKE_LOG_DIR:-${RUNNER_TEMP:-/tmp}/spark-connector-smoke-${SPARK_MINOR}-$$}"
+STARROCKS_IMAGE_DEFAULT="starrocks/allin1-ubuntu:3.5.5@sha256:711dbcdec06a93858bf37ab6e197f36fa707e0488bd4f9c06fa1c666d9ef8149"
+STARROCKS_IMAGE="${STARROCKS_IMAGE:-$STARROCKS_IMAGE_DEFAULT}"
+SPARK_IMAGE="${SPARK_IMAGE:-$(spark_official_image "$SPARK_MINOR")}"
+SPARK_MASTER_UI_PORT="${SPARK_MASTER_UI_PORT:-28080}"
+STARROCKS_FE_HTTP_PORT="${STARROCKS_FE_HTTP_PORT:-8030}"
+STARROCKS_FE_JDBC_PORT="${STARROCKS_FE_JDBC_PORT:-9030}"
+STARROCKS_BE_HTTP_PORT="${STARROCKS_BE_HTTP_PORT:-8040}"
+STARROCKS_BE_THRIFT_PORT="${STARROCKS_BE_THRIFT_PORT:-9060}"
+STARROCKS_BE_BRPC_PORT="${STARROCKS_BE_BRPC_PORT:-8060}"
+STARROCKS_FE_HTTP_HOST_PORT="${STARROCKS_FE_HTTP_HOST_PORT:-18030}"
+STARROCKS_FE_JDBC_HOST_PORT="${STARROCKS_FE_JDBC_HOST_PORT:-19030}"
+STARROCKS_BE_HTTP_HOST_PORT="${STARROCKS_BE_HTTP_HOST_PORT:-18040}"
+STARROCKS_BE_THRIFT_HOST_PORT="${STARROCKS_BE_THRIFT_HOST_PORT:-19060}"
+STARROCKS_BE_BRPC_HOST_PORT="${STARROCKS_BE_BRPC_HOST_PORT:-18060}"
+STARROCKS_STARTUP_TIMEOUT_SECONDS="${STARROCKS_STARTUP_TIMEOUT_SECONDS:-480}"
+SPARK_STARTUP_TIMEOUT_SECONDS="${SPARK_STARTUP_TIMEOUT_SECONDS:-120}"
+SMOKE_TIMEOUT_SECONDS="${SMOKE_TIMEOUT_SECONDS:-900}"
+
+read -r -a DOCKER_COMMAND_PARTS <<< "${DOCKER_COMMAND:-docker}"
+RUN_TOKEN="${GITHUB_RUN_ID:-$$}-${GITHUB_RUN_ATTEMPT:-1}-${SPARK_MINOR//./-}"
+CLUSTER_NETWORK="spark-ci-$RUN_TOKEN"
+STARROCKS_CONTAINER="spark-ci-starrocks-$RUN_TOKEN"
+SPARK_MASTER_CONTAINER="spark-ci-master-$RUN_TOKEN"
+SPARK_WORKER_CONTAINER="spark-ci-worker-$RUN_TOKEN"
+SPARK_DRIVER_CONTAINER="spark-ci-driver-$RUN_TOKEN"
+NETWORK_CREATED=false
+
+mkdir -p "$SMOKE_LOG_DIR" "$SMOKE_LOG_DIR/spark" "$SMOKE_LOG_DIR/spark-events" \
+  "$SMOKE_LOG_DIR/spark-work" "$SMOKE_LOG_DIR/shared-work" \
+  "$SMOKE_LOG_DIR/driver-artifacts"
+chmod a+rwx "$SMOKE_LOG_DIR/spark-events" "$SMOKE_LOG_DIR/spark-work" \
+  "$SMOKE_LOG_DIR/shared-work"
+
+docker_command() {
+  "${DOCKER_COMMAND_PARTS[@]}" "$@"
+}
+
+collect_container_diagnostics() {
+  local label="$1" container="$2"
+  if docker_command inspect "$container" >/dev/null 2>&1; then
+    docker_command logs "$container" > "$SMOKE_LOG_DIR/$label.log" 2>&1
+    docker_command inspect "$container" > "$SMOKE_LOG_DIR/$label-inspect.json" 2>&1
+  fi
+}
+
+collect_diagnostics() {
+  collect_container_diagnostics spark-master "$SPARK_MASTER_CONTAINER"
+  collect_container_diagnostics spark-worker "$SPARK_WORKER_CONTAINER"
+  collect_container_diagnostics spark-driver "$SPARK_DRIVER_CONTAINER"
+  collect_container_diagnostics starrocks-container "$STARROCKS_CONTAINER"
+  if docker_command inspect "$STARROCKS_CONTAINER" >/dev/null 2>&1; then
+    docker_command cp "$STARROCKS_CONTAINER:/data/deploy/starrocks/fe/log" \
+      "$SMOKE_LOG_DIR/starrocks-fe-log" >/dev/null 2>&1
+    docker_command cp "$STARROCKS_CONTAINER:/data/deploy/starrocks/be/log" \
+      "$SMOKE_LOG_DIR/starrocks-be-log" >/dev/null 2>&1
+  fi
+}
+
+cleanup() {
+  local status=$? container
+  local -a diagnostics_permissions_args=()
+  trap - EXIT
+  set +e
+  collect_diagnostics
+  for container in \
+      "$SPARK_DRIVER_CONTAINER" "$SPARK_WORKER_CONTAINER" \
+      "$SPARK_MASTER_CONTAINER" "$STARROCKS_CONTAINER"; do
+    if docker_command inspect "$container" >/dev/null 2>&1; then
+      docker_command rm --force "$container" >> "$SMOKE_LOG_DIR/cleanup.log" 2>&1
+    fi
+  done
+  if docker_command image inspect "$SPARK_IMAGE" >/dev/null 2>&1; then
+    spark_diagnostics_permissions_container_args \
+      diagnostics_permissions_args "$SPARK_IMAGE" "$SMOKE_LOG_DIR"
+    docker_command "${diagnostics_permissions_args[@]}" \
+      >> "$SMOKE_LOG_DIR/cleanup.log" 2>&1
+  fi
+  if [ "$NETWORK_CREATED" = true ]; then
+    docker_command network rm "$CLUSTER_NETWORK" >> "$SMOKE_LOG_DIR/cleanup.log" 2>&1
+  fi
+  printf 'cleanup_exit_status=%s\n' "$status" >> "$SMOKE_LOG_DIR/cleanup.log"
+  exit "$status"
+}
+trap cleanup EXIT
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    ci_error "required command is unavailable: $1"
+    exit 1
+  }
+}
+
+for command_name in cp curl jar java sha256sum timeout; do
+  require_command "$command_name"
+done
+require_command "${DOCKER_COMMAND_PARTS[0]}"
+
+if ! JAVA_VERSION_OUTPUT="$(java -version 2>&1)"; then
+  ci_error "failed to run the host Java runtime"
+  exit 1
+fi
+if ! java_output_matches_major "$EXPECTED_BUILD_JAVA" "$JAVA_VERSION_OUTPUT"; then
+  ci_error "Spark $SPARK_MINOR connector build requires JDK $EXPECTED_BUILD_JAVA, but java reports: $(first_line "$JAVA_VERSION_OUTPUT")"
+  exit 1
+fi
+
+docker_command info > "$SMOKE_LOG_DIR/docker-info.txt"
+
+CONNECTOR_JAR="$(find_connector_jar "$REPO_ROOT" "$SPARK_MINOR" "$SCALA_BINARY")"
+verify_connector_jar "$CONNECTOR_JAR" "$SPARK_MINOR" "$SCALA_BINARY" \
+  | tee "$SMOKE_LOG_DIR/connector-verification.txt"
+sha256sum "$CONNECTOR_JAR" > "$SMOKE_LOG_DIR/connector.sha256"
+jar tf "$CONNECTOR_JAR" > "$SMOKE_LOG_DIR/connector-entries.txt"
+
+MYSQL_JAR="$(find_mysql_jar "$MAVEN_REPO")"
+
+DRIVER_ARTIFACT_DIR="$SMOKE_LOG_DIR/driver-artifacts"
+CONNECTOR_BASENAME="$(basename "$CONNECTOR_JAR")"
+MYSQL_BASENAME="$(basename "$MYSQL_JAR")"
+SMOKE_BASENAME="connector-docs-smoke-${SPARK_MINOR}.jar"
+SMOKE_JAR="$DRIVER_ARTIFACT_DIR/$SMOKE_BASENAME"
+package_smoke_jar "$REPO_ROOT" "$SMOKE_JAR" >/dev/null
+jar tf "$SMOKE_JAR" > "$SMOKE_LOG_DIR/smoke-jar-entries.txt"
+cp "$CONNECTOR_JAR" "$DRIVER_ARTIFACT_DIR/$CONNECTOR_BASENAME"
+cp "$MYSQL_JAR" "$DRIVER_ARTIFACT_DIR/$MYSQL_BASENAME"
+
+printf 'Starting Apache official Spark image %s\n' "$SPARK_IMAGE"
+if docker_command image inspect "$SPARK_IMAGE" >/dev/null 2>&1; then
+  printf 'Using locally available Apache Spark image %s\n' "$SPARK_IMAGE" \
+    | tee "$SMOKE_LOG_DIR/spark-image-pull.log"
+else
+  retry_command 3 5 docker_command pull --platform linux/amd64 "$SPARK_IMAGE" \
+    | tee "$SMOKE_LOG_DIR/spark-image-pull.log"
+fi
+if ! CONTAINER_JAVA_OUTPUT="$(
+    docker_command run --rm --platform linux/amd64 \
+      --entrypoint java "$SPARK_IMAGE" -version 2>&1
+  )"; then
+  ci_error "failed to run Java from Apache Spark image: $SPARK_IMAGE"
+  exit 1
+fi
+if ! java_output_matches_major "$EXPECTED_RUNTIME_JAVA" "$CONTAINER_JAVA_OUTPUT"; then
+  ci_error "Spark $SPARK_MINOR official image should use JDK $EXPECTED_RUNTIME_JAVA, but reports: $(first_line "$CONTAINER_JAVA_OUTPUT")"
+  exit 1
+fi
+if ! CONTAINER_SPARK_OUTPUT="$(
+    docker_command run --rm --platform linux/amd64 \
+      --entrypoint /opt/spark/bin/spark-submit "$SPARK_IMAGE" --version 2>&1
+  )"; then
+  ci_error "failed to run spark-submit from Apache Spark image: $SPARK_IMAGE"
+  exit 1
+fi
+if ! spark_output_matches_version "$SPARK_FULL_VERSION" "$CONTAINER_SPARK_OUTPUT"; then
+  ci_error "Apache Spark image does not report expected version $SPARK_FULL_VERSION"
+  exit 1
+fi
+printf '%s\n' "$CONTAINER_JAVA_OUTPUT" > "$SMOKE_LOG_DIR/spark-image-java.txt"
+printf '%s\n' "$CONTAINER_SPARK_OUTPUT" > "$SMOKE_LOG_DIR/spark-image-version.txt"
+printf 'Verified Apache Spark %s image with JDK %s\n' \
+  "$SPARK_FULL_VERSION" "$EXPECTED_RUNTIME_JAVA"
+docker_command network create "$CLUSTER_NETWORK" \
+  > "$SMOKE_LOG_DIR/cluster-network-id.txt"
+NETWORK_CREATED=true
+
+printf 'Starting StarRocks image %s\n' "$STARROCKS_IMAGE"
+if docker_command image inspect "$STARROCKS_IMAGE" >/dev/null 2>&1; then
+  printf 'Using cached StarRocks image %s\n' "$STARROCKS_IMAGE" \
+    | tee "$SMOKE_LOG_DIR/starrocks-pull.log"
+else
+  retry_command 3 5 docker_command pull "$STARROCKS_IMAGE" \
+    | tee "$SMOKE_LOG_DIR/starrocks-pull.log"
+fi
+docker_command run --detach --rm --platform linux/amd64 \
+  --network "$CLUSTER_NETWORK" \
+  --network-alias starrocks \
+  --hostname starrocks \
+  --publish "${STARROCKS_FE_HTTP_HOST_PORT}:${STARROCKS_FE_HTTP_PORT}" \
+  --publish "${STARROCKS_FE_JDBC_HOST_PORT}:${STARROCKS_FE_JDBC_PORT}" \
+  --publish "${STARROCKS_BE_HTTP_HOST_PORT}:${STARROCKS_BE_HTTP_PORT}" \
+  --publish "${STARROCKS_BE_THRIFT_HOST_PORT}:${STARROCKS_BE_THRIFT_PORT}" \
+  --publish "${STARROCKS_BE_BRPC_HOST_PORT}:${STARROCKS_BE_BRPC_PORT}" \
+  --volume "$SCRIPT_DIR/start-starrocks.sh:/opt/starrocks-ci/start-starrocks.sh:ro" \
+  --entrypoint /bin/bash \
+  --name "$STARROCKS_CONTAINER" "$STARROCKS_IMAGE" \
+  /opt/starrocks-ci/start-starrocks.sh \
+  > "$SMOKE_LOG_DIR/starrocks-container-id.txt"
+
+STARROCKS_DEADLINE=$((SECONDS + STARROCKS_STARTUP_TIMEOUT_SECONDS))
+while [ "$SECONDS" -lt "$STARROCKS_DEADLINE" ]; do
+  http_ready=false
+  backend_ready=false
+  http_code="$(curl --silent --show-error --max-time 5 \
+      "http://127.0.0.1:${STARROCKS_FE_HTTP_HOST_PORT}/" \
+      --output "$SMOKE_LOG_DIR/starrocks-fe-http.txt" --write-out '%{http_code}' \
+      2>> "$SMOKE_LOG_DIR/readiness.log" || true)"
+  if http_response_is_ready "$http_code"; then
+    http_ready=true
+  fi
+  if docker_command exec "$STARROCKS_CONTAINER" mysql --batch \
+      -h127.0.0.1 -P"$STARROCKS_FE_JDBC_PORT" -uroot \
+      -e 'SHOW BACKENDS' > "$SMOKE_LOG_DIR/starrocks-backends.tsv" \
+      2>> "$SMOKE_LOG_DIR/readiness.log" \
+      && starrocks_backend_is_alive "$SMOKE_LOG_DIR/starrocks-backends.tsv"; then
+    backend_ready=true
+  fi
+  if [ "$http_ready" = true ] && [ "$backend_ready" = true ]; then
+    break
+  fi
+  sleep 2
+done
+if [ "${http_ready:-false}" != true ] || [ "${backend_ready:-false}" != true ]; then
+  ci_error "StarRocks did not become ready within ${STARROCKS_STARTUP_TIMEOUT_SECONDS}s"
+  exit 1
+fi
+printf 'StarRocks FE and BE are ready\n' | tee -a "$SMOKE_LOG_DIR/readiness.log"
+
+declare -a SPARK_MASTER_ARGS=() SPARK_WORKER_ARGS=() SPARK_DRIVER_ARGS=()
+spark_master_container_args \
+  SPARK_MASTER_ARGS "$SPARK_MASTER_CONTAINER" "$CLUSTER_NETWORK" \
+  "$SPARK_IMAGE" "$SPARK_MASTER_UI_PORT"
+docker_command "${SPARK_MASTER_ARGS[@]}" | tee "$SMOKE_LOG_DIR/spark-master-id.txt"
+
+spark_worker_container_args \
+  SPARK_WORKER_ARGS "$SPARK_WORKER_CONTAINER" "$CLUSTER_NETWORK" \
+  "$SPARK_IMAGE" "$SMOKE_LOG_DIR/shared-work" \
+  "$SMOKE_LOG_DIR/spark-work"
+docker_command "${SPARK_WORKER_ARGS[@]}" | tee "$SMOKE_LOG_DIR/spark-worker-id.txt"
+
+SPARK_DEADLINE=$((SECONDS + SPARK_STARTUP_TIMEOUT_SECONDS))
+while [ "$SECONDS" -lt "$SPARK_DEADLINE" ]; do
+  if curl --fail --silent --show-error --max-time 5 \
+      "http://127.0.0.1:${SPARK_MASTER_UI_PORT}/json/" \
+      > "$SMOKE_LOG_DIR/spark-master-status.json" \
+      2>> "$SMOKE_LOG_DIR/readiness.log" \
+      && spark_worker_is_alive "$SMOKE_LOG_DIR/spark-master-status.json"; then
+    break
+  fi
+  sleep 2
+done
+if ! spark_worker_is_alive "$SMOKE_LOG_DIR/spark-master-status.json"; then
+  ci_error "Spark worker did not register within ${SPARK_STARTUP_TIMEOUT_SECONDS}s"
+  exit 1
+fi
+printf 'Spark standalone worker is ALIVE\n' | tee -a "$SMOKE_LOG_DIR/readiness.log"
+
+RUN_ID="${GITHUB_RUN_ID:-$$}_${GITHUB_RUN_ATTEMPT:-1}"
+DATABASE="ci_spark_${SPARK_MINOR//./_}_${RUN_ID}"
+APPLICATION_LOG="$SMOKE_LOG_DIR/application.log"
+
+spark_driver_container_args \
+  SPARK_DRIVER_ARGS "$SPARK_DRIVER_CONTAINER" "$CLUSTER_NETWORK" \
+  "$SPARK_IMAGE" "$DRIVER_ARTIFACT_DIR" \
+  "$SMOKE_LOG_DIR/shared-work" "$SMOKE_LOG_DIR/spark-events"
+SPARK_DRIVER_ARGS+=(
+  --master spark://spark-master:7077
+  --deploy-mode client
+  --class com.starrocks.connector.spark.ci.ConnectorDocsSmoke
+  --conf spark.driver.host=spark-driver
+  --conf spark.driver.bindAddress=0.0.0.0
+  --conf spark.cores.max=2
+  --conf spark.executor.cores=2
+  --conf spark.executor.memory=512m
+  --conf spark.eventLog.enabled=true
+  --conf spark.eventLog.dir=file:///opt/spark-events
+  --jars "/opt/spark-driver/$CONNECTOR_BASENAME,/opt/spark-driver/$MYSQL_BASENAME"
+  "/opt/spark-driver/$SMOKE_BASENAME"
+  "$DATABASE"
+  /opt/spark-shared
+  starrocks:8030
+  jdbc:mysql://starrocks:9030
+  "$CONNECTOR_BASENAME"
+)
+
+set +e
+timeout "$SMOKE_TIMEOUT_SECONDS" \
+  "${DOCKER_COMMAND_PARTS[@]}" "${SPARK_DRIVER_ARGS[@]}" \
+  2>&1 | tee "$APPLICATION_LOG"
+SUBMIT_STATUS=${PIPESTATUS[0]}
+set -e
+
+if [ "$SUBMIT_STATUS" -ne 0 ]; then
+  ci_error "Spark $SPARK_MINOR smoke application failed with status $SUBMIT_STATUS"
+  exit "$SUBMIT_STATUS"
+fi
+if ! executor_evidence_uses_host "$APPLICATION_LOG" spark-worker; then
+  ci_error "distributed execution did not run exclusively in the Spark worker container"
+  exit 1
+fi
+
+CHECK_COUNT="$(grep -Ec '^CHECK [a-z_]+ PASS ' "$APPLICATION_LOG" || true)"
+if [ "$CHECK_COUNT" -ne 8 ]; then
+  ci_error "Spark $SPARK_MINOR smoke application reported $CHECK_COUNT checks, expected 8"
+  exit 1
+fi
+if ! grep -Fq "VALIDATION_RESULT PASS spark=$SPARK_FULL_VERSION database=$DATABASE" "$APPLICATION_LOG"; then
+  ci_error "Spark $SPARK_MINOR smoke application did not report the expected final PASS record"
+  exit 1
+fi
+
+{
+  printf 'spark_minor=%s\n' "$SPARK_MINOR"
+  printf 'spark_version=%s\n' "$SPARK_FULL_VERSION"
+  printf 'scala_binary=%s\n' "$SCALA_BINARY"
+  printf 'build_java=%s\n' "$(first_line "$JAVA_VERSION_OUTPUT")"
+  printf 'runtime_java=%s\n' "$(first_line "$CONTAINER_JAVA_OUTPUT")"
+  printf 'connector=%s\n' "$CONNECTOR_JAR"
+  printf 'connector_sha256=%s\n' "$(awk '{print $1}' "$SMOKE_LOG_DIR/connector.sha256")"
+  printf 'spark_image=%s\n' "$SPARK_IMAGE"
+  printf 'spark_topology=containerized-master-worker-driver\n'
+  printf 'starrocks_image=%s\n' "$STARROCKS_IMAGE"
+  printf 'checks=%s\n' "$CHECK_COUNT"
+  printf 'result=PASS\n'
+} > "$SMOKE_LOG_DIR/summary.txt"
+
+cat "$SMOKE_LOG_DIR/summary.txt"

--- a/ci/real-cluster/spark-containers.sh
+++ b/ci/real-cluster/spark-containers.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+spark_container_common_args() {
+  local output_name="$1" container_name="$2" hostname="$3" network="$4"
+  local -n output="$output_name"
+
+  output=(
+    run
+    --init
+    --platform linux/amd64
+    --network "$network"
+    --name "$container_name"
+    --hostname "$hostname"
+    --network-alias "$hostname"
+  )
+}
+
+spark_master_container_args() {
+  local output_name="$1" container_name="$2" network="$3" image="$4"
+  local web_ui_host_port="$5"
+  local -n output="$output_name"
+
+  spark_container_common_args \
+    "$output_name" "$container_name" spark-master "$network"
+  output+=(
+    --publish "127.0.0.1:${web_ui_host_port}:8080"
+    --detach
+    --entrypoint /opt/spark/bin/spark-class
+    "$image"
+    org.apache.spark.deploy.master.Master
+    --host spark-master
+    --port 7077
+    --webui-port 8080
+  )
+}
+
+spark_worker_container_args() {
+  local output_name="$1" container_name="$2" network="$3" image="$4"
+  local shared_work="$5" worker_work="$6"
+  local -n output="$output_name"
+
+  spark_container_common_args \
+    "$output_name" "$container_name" spark-worker "$network"
+  output+=(
+    --volume "$shared_work:/opt/spark-shared"
+    --volume "$worker_work:/opt/spark-work"
+    --env SPARK_WORKER_DIR=/opt/spark-work
+    --detach
+    --entrypoint /opt/spark/bin/spark-class
+    "$image"
+    org.apache.spark.deploy.worker.Worker
+    --host spark-worker
+    --port 7078
+    --webui-port 8081
+    --cores 2
+    --memory 1g
+    spark://spark-master:7077
+  )
+}
+
+spark_driver_container_args() {
+  local output_name="$1" container_name="$2" network="$3" image="$4"
+  local artifacts="$5" shared_work="$6" events="$7"
+  local -n output="$output_name"
+
+  spark_container_common_args \
+    "$output_name" "$container_name" spark-driver "$network"
+  output+=(
+    --volume "$artifacts:/opt/spark-driver:ro"
+    --volume "$shared_work:/opt/spark-shared"
+    --volume "$events:/opt/spark-events"
+    --entrypoint /opt/spark/bin/spark-submit
+    "$image"
+  )
+}
+
+spark_diagnostics_permissions_container_args() {
+  local output_name="$1" image="$2" diagnostics="$3"
+  local -n output="$output_name"
+
+  output=(
+    run
+    --rm
+    --volume "$diagnostics:/diagnostics"
+    --user 0:0
+    --entrypoint chmod
+    "$image"
+    -R
+    a+rX
+    /diagnostics
+  )
+}

--- a/ci/real-cluster/start-starrocks.sh
+++ b/ci/real-cluster/start-starrocks.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+
+STARROCKS_HOME="${SR_HOME:-/data/deploy/starrocks}"
+IMAGE_ENTRYPOINT="/data/deploy/entrypoint.sh"
+DIRECTOR_SCRIPT="$STARROCKS_HOME/director/run.sh"
+container_ip="$(hostname -i | awk '{print $1}')"
+
+if [ -z "$container_ip" ]; then
+  printf 'Unable to resolve the StarRocks container bridge address\n' >&2
+  exit 1
+fi
+
+# The all-in-one image deliberately binds FE and BE to loopback. That makes
+# redirects unusable from an external Spark executor, so register both services
+# on the container's bridge address for this real-cluster test.
+sed -i \
+  "s|priority_networks = 127.0.0.1/32|priority_networks = ${container_ip}/32|g" \
+  "$IMAGE_ENTRYPOINT"
+sed -i \
+  "s|^MYHOST=127.0.0.1$|MYHOST=${container_ip}|" \
+  "$DIRECTOR_SCRIPT"
+
+exec "$IMAGE_ENTRYPOINT"

--- a/ci/real-cluster/tests/run_tests.sh
+++ b/ci/real-cluster/tests/run_tests.sh
@@ -1,0 +1,506 @@
+#!/usr/bin/env bash
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CI_DIR="$(cd "$TEST_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$CI_DIR/../.." && pwd)"
+
+# shellcheck disable=SC1091
+source "$CI_DIR/lib.sh"
+if [ -f "$CI_DIR/spark-containers.sh" ]; then
+  # shellcheck disable=SC1091
+  source "$CI_DIR/spark-containers.sh"
+fi
+
+passed=0
+failed=0
+
+pass() {
+  printf 'PASS %s\n' "$1"
+  passed=$((passed + 1))
+}
+
+fail() {
+  printf 'FAIL %s: %s\n' "$1" "$2" >&2
+  failed=$((failed + 1))
+}
+
+assert_success() {
+  local name="$1"
+  shift
+  if "$@"; then
+    pass "$name"
+  else
+    fail "$name" "expected success"
+  fi
+}
+
+assert_failure() {
+  local name="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    fail "$name" "expected failure"
+  else
+    pass "$name"
+  fi
+}
+
+array_contains_sequence() {
+  local array_name="$1"
+  shift
+  local -n values="$array_name"
+  local start expected_index
+  for ((start = 0; start <= ${#values[@]} - $#; start++)); do
+    for ((expected_index = 1; expected_index <= $#; expected_index++)); do
+      if [ "${values[start + expected_index - 1]}" != "${!expected_index}" ]; then
+        break
+      fi
+    done
+    if [ "$expected_index" -gt "$#" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+array_contains_value() {
+  local array_name="$1" expected="$2" value
+  local -n values="$array_name"
+  for value in "${values[@]}"; do
+    [ "$value" = "$expected" ] && return 0
+  done
+  return 1
+}
+
+array_contains_mount_target() {
+  local array_name="$1" target="$2" value
+  local -n values="$array_name"
+  for value in "${values[@]}"; do
+    case "$value" in
+      *:"$target"|*:"$target":*) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+make_fixture_jar() {
+  local destination="$1" spark="$2"
+  local fixture scala artifact
+  fixture="$(mktemp -d)"
+  scala="$(spark_scala_binary "$spark")"
+  artifact="starrocks-spark-connector-${spark}_${scala}"
+  mkdir -p "$fixture/com/starrocks/connector/spark/sql"
+  mkdir -p "$fixture/META-INF/maven/com.starrocks/$artifact"
+  printf 'connector' > "$fixture/com/starrocks/connector/spark/sql/StarRocksDataSourceProvider.class"
+  printf 'groupId=com.starrocks\nartifactId=%s\nversion=1.2.0\n' "$artifact" \
+    > "$fixture/META-INF/maven/com.starrocks/$artifact/pom.properties"
+
+  (cd "$fixture" && jar cf "$destination" .)
+  rm -rf "$fixture"
+}
+
+test_version_mappings() {
+  local expected actual spark
+  declare -F spark_build_java_major >/dev/null || return 1
+  declare -F spark_runtime_java_major >/dev/null || return 1
+  expected=$'3.3|3.3.2|2.12|8|11\n3.4|3.4.0|2.12|8|11\n3.5|3.5.0|2.12|8|11\n4.0|4.0.0|2.13|17|17\n4.1|4.1.0|2.13|17|17'
+  actual=""
+  for spark in 3.3 3.4 3.5 4.0 4.1; do
+    actual+="${spark}|$(spark_full_version "$spark")|$(spark_scala_binary "$spark")|$(spark_build_java_major "$spark")|$(spark_runtime_java_major "$spark")"$'\n'
+  done
+  [ "${actual%$'\n'}" = "$expected" ]
+}
+
+test_official_spark_images_are_pinned() {
+  local expected actual spark
+  declare -F spark_official_image >/dev/null || return 1
+  expected=$'3.3|apache/spark-py:v3.3.2@sha256:5bb83c62a12546bc0abd5196df301ec64085aa5c38cc9e144c6135d740596c7a\n3.4|apache/spark:3.4.0@sha256:55e67077c859e14b6ea5600dc9dfd67219054c6feed0689558ff07bb4b2c9579\n3.5|apache/spark:3.5.0@sha256:0ed5154e6b32ac3af1272d4d65e9f65b13afcfe80b41ad10bd059bcd6317863c\n4.0|apache/spark:4.0.0@sha256:a89782d90529a623fc4471cdddb0f9c32d6eed10a81b256a80207b23c3b1df00\n4.1|apache/spark:4.1.0-scala2.13-java17-python3-ubuntu@sha256:deaccd823f4bb2b6ed48443abd1ab35669bf9d6c226cf17098d6203182797252'
+  actual=""
+  for spark in 3.3 3.4 3.5 4.0 4.1; do
+    actual+="${spark}|$(spark_official_image "$spark")"$'\n'
+  done
+  [ "${actual%$'\n'}" = "$expected" ] \
+    && ! spark_official_image 3.2 >/dev/null 2>&1
+}
+
+test_java_output_is_parsed_without_a_pipe() {
+  [ "$(first_line $'openjdk version "17.0.20"\nRuntime line\nVM line')" = \
+      'openjdk version "17.0.20"' ] \
+    && java_output_matches_major 17 $'openjdk version "17.0.20"\nRuntime line' \
+    && java_output_matches_major 11 $'openjdk version "11.0.20"\nRuntime line' \
+    && java_output_matches_major 8 $'openjdk version "1.8.0_502"\nRuntime line' \
+    && ! java_output_matches_major 8 'openjdk version "17.0.20"'
+}
+
+test_spark_version_output_is_parsed() {
+  declare -F spark_output_matches_version >/dev/null || return 1
+  spark_output_matches_version 3.3.2 $'Welcome to\nversion 3.3.2\n' \
+    && spark_output_matches_version 4.1.0 $'Welcome to\nversion 4.1.0\n' \
+    && ! spark_output_matches_version 4.1.0 $'Welcome to\nversion 4.0.0\n'
+}
+
+retry_test_attempts=0
+
+succeed_on_third_attempt() {
+  retry_test_attempts=$((retry_test_attempts + 1))
+  [ "$retry_test_attempts" -eq 3 ]
+}
+
+test_retry_command_retries_transient_failures() {
+  retry_test_attempts=0
+  retry_command 3 0 succeed_on_third_attempt 2>/dev/null \
+    && [ "$retry_test_attempts" -eq 3 ]
+}
+
+test_unsupported_version_rejected() {
+  ! spark_full_version 3.2 >/dev/null 2>&1
+}
+
+test_find_connector_jar() {
+  local work expected actual
+  work="$(mktemp -d)"
+  mkdir -p "$work/target"
+  touch \
+    "$work/target/original-starrocks-spark-connector-4.1_2.13-1.2.0.jar" \
+    "$work/target/starrocks-spark-connector-4.1_2.13-1.2.0-sources.jar" \
+    "$work/target/starrocks-spark-connector-4.1_2.13-1.2.0-javadoc.jar"
+  expected="$work/target/starrocks-spark-connector-4.1_2.13-1.2.0.jar"
+  touch "$expected"
+  actual="$(find_connector_jar "$work" 4.1 2.13)" || return 1
+  rm -rf "$work"
+  [ "$actual" = "$expected" ]
+}
+
+test_missing_connector_jar_rejected() {
+  local work
+  work="$(mktemp -d)"
+  mkdir -p "$work/target"
+  if find_connector_jar "$work" 4.1 2.13 >/dev/null 2>&1; then
+    rm -rf "$work"
+    return 1
+  fi
+  rm -rf "$work"
+}
+
+test_multiple_connector_jars_rejected() {
+  local work
+  work="$(mktemp -d)"
+  mkdir -p "$work/target"
+  touch \
+    "$work/target/starrocks-spark-connector-4.1_2.13-1.2.0.jar" \
+    "$work/target/starrocks-spark-connector-4.1_2.13-1.2.1.jar"
+  if find_connector_jar "$work" 4.1 2.13 >/dev/null 2>&1; then
+    rm -rf "$work"
+    return 1
+  fi
+  rm -rf "$work"
+}
+
+test_connector_jars_for_all_versions_accepted() {
+  local work jar spark scala
+  work="$(mktemp -d)"
+  for spark in 3.3 3.4 3.5 4.0 4.1; do
+    scala="$(spark_scala_binary "$spark")"
+    jar="$work/starrocks-spark-connector-${spark}_${scala}-1.2.0.jar"
+    make_fixture_jar "$jar" "$spark"
+    verify_connector_jar "$jar" "$spark" "$scala" >/dev/null || {
+      rm -rf "$work"
+      return 1
+    }
+  done
+  rm -rf "$work"
+}
+
+test_smoke_jar_requires_compiled_classes() {
+  local work
+  work="$(mktemp -d)"
+  mkdir -p "$work/target/test-classes"
+  if package_smoke_jar "$work" "$work/smoke.jar" >/dev/null 2>&1; then
+    rm -rf "$work"
+    return 1
+  fi
+  rm -rf "$work"
+}
+
+test_smoke_jar_contains_only_smoke_classes() {
+  local work classes jar entries
+  work="$(mktemp -d)"
+  classes="$work/target/test-classes/com/starrocks/connector/spark/ci"
+  jar="$work/smoke.jar"
+  mkdir -p "$classes"
+  printf 'main' > "$classes/ConnectorDocsSmoke.class"
+  printf 'closure' > "$classes/ConnectorDocsSmoke\$\$anonfun\$1.class"
+  printf 'not-smoke' > "$classes/AnotherTest.class"
+  package_smoke_jar "$work" "$jar" >/dev/null || return 1
+  entries="$(jar tf "$jar")" || return 1
+  rm -rf "$work"
+  printf '%s\n' "$entries" \
+    | grep -Fxq 'com/starrocks/connector/spark/ci/ConnectorDocsSmoke.class' \
+    && printf '%s\n' "$entries" \
+      | grep -Fxq 'com/starrocks/connector/spark/ci/ConnectorDocsSmoke$$anonfun$1.class' \
+    && ! printf '%s\n' "$entries" | grep -Fq 'AnotherTest.class' \
+    && ! printf '%s\n' "$entries" | grep -Eq '^(org/apache/spark|scala|com/mysql)/'
+}
+
+test_find_mysql_jar() {
+  local work expected actual
+  work="$(mktemp -d)"
+  expected="$work/com/mysql/mysql-connector-j/8.0.33/mysql-connector-j-8.0.33.jar"
+  mkdir -p "$(dirname "$expected")"
+  touch "$expected"
+  actual="$(find_mysql_jar "$work")" || return 1
+  rm -rf "$work"
+  [ "$actual" = "$expected" ]
+}
+
+test_missing_mysql_jar_rejected() {
+  local work
+  work="$(mktemp -d)"
+  if find_mysql_jar "$work" >/dev/null 2>&1; then
+    rm -rf "$work"
+    return 1
+  fi
+  rm -rf "$work"
+}
+
+test_spark_worker_readiness_parser() {
+  local work
+  work="$(mktemp -d)"
+  printf '{"workers":[{"id":"worker-1","state":"ALIVE"}]}\n' > "$work/alive.json"
+  printf '{"workers":[]}\n' > "$work/empty.json"
+  spark_worker_is_alive "$work/alive.json" \
+    && ! spark_worker_is_alive "$work/empty.json"
+  local status=$?
+  rm -rf "$work"
+  return "$status"
+}
+
+test_starrocks_backend_readiness_parser() {
+  local work
+  work="$(mktemp -d)"
+  printf 'BackendId\tIP\tAlive\n10001\t127.0.0.1\ttrue\n' > "$work/alive.tsv"
+  printf 'BackendId\tIP\tAlive\n10001\t127.0.0.1\tfalse\n' > "$work/dead.tsv"
+  starrocks_backend_is_alive "$work/alive.tsv" \
+    && ! starrocks_backend_is_alive "$work/dead.tsv"
+  local status=$?
+  rm -rf "$work"
+  return "$status"
+}
+
+test_fe_http_readiness_accepts_authentication_response() {
+  http_response_is_ready 200 \
+    && http_response_is_ready 401 \
+    && ! http_response_is_ready 000 \
+    && ! http_response_is_ready error
+}
+
+test_cluster_runner_rejects_bad_arguments() {
+  ! "$CI_DIR/run.sh" >/dev/null 2>&1 \
+    && ! "$CI_DIR/run.sh" 3.2 >/dev/null 2>&1
+}
+
+test_spark_roles_use_one_container_network() {
+  declare -F spark_master_container_args >/dev/null || return 1
+  declare -F spark_worker_container_args >/dev/null || return 1
+  declare -F spark_driver_container_args >/dev/null || return 1
+
+  local -a master_args=() worker_args=() driver_args=()
+  spark_master_container_args master_args master-id cluster-net official-spark-image 28080
+  spark_worker_container_args \
+    worker_args worker-id cluster-net official-spark-image /shared /worker
+  spark_driver_container_args \
+    driver_args driver-id cluster-net official-spark-image /artifacts /shared /events
+
+  array_contains_sequence master_args --network cluster-net \
+    && array_contains_sequence master_args --hostname spark-master \
+    && array_contains_sequence master_args --publish 127.0.0.1:28080:8080 \
+    && array_contains_sequence master_args --entrypoint /opt/spark/bin/spark-class \
+      official-spark-image org.apache.spark.deploy.master.Master \
+    && array_contains_sequence worker_args --network cluster-net \
+    && array_contains_sequence worker_args --hostname spark-worker \
+    && array_contains_sequence worker_args --entrypoint /opt/spark/bin/spark-class \
+      official-spark-image org.apache.spark.deploy.worker.Worker \
+    && array_contains_sequence driver_args --network cluster-net \
+    && array_contains_sequence driver_args --hostname spark-driver \
+    && array_contains_sequence driver_args --entrypoint /opt/spark/bin/spark-submit \
+      official-spark-image \
+    && ! array_contains_mount_target master_args /opt/spark \
+    && ! array_contains_mount_target worker_args /opt/spark \
+    && ! array_contains_mount_target driver_args /opt/spark
+}
+
+test_executor_evidence_requires_worker_container() {
+  local work good bad
+  work="$(mktemp -d)"
+  good="$work/good.log"
+  bad="$work/bad.log"
+  printf '%s\n' \
+    'CHECK distributed_execution PASS 1@spark-worker:10:spark://driver/jars/connector.jar,1@spark-worker:20:spark://driver/jars/connector.jar' \
+    > "$good"
+  printf '%s\n' \
+    'CHECK distributed_execution PASS 1@runner-host:10:file:/workspace/connector.jar' \
+    > "$bad"
+
+  executor_evidence_uses_host "$good" spark-worker \
+    && ! executor_evidence_uses_host "$bad" spark-worker
+  local status=$?
+  rm -rf "$work"
+  return "$status"
+}
+
+test_worker_has_shared_data_but_not_driver_artifacts() {
+  declare -F spark_worker_container_args >/dev/null || return 1
+  declare -F spark_driver_container_args >/dev/null || return 1
+
+  local -a worker_args=() driver_args=()
+  spark_worker_container_args \
+    worker_args worker-id cluster-net official-spark-image /shared /worker
+  spark_driver_container_args \
+    driver_args driver-id cluster-net official-spark-image /artifacts /shared /events
+
+  array_contains_value worker_args /shared:/opt/spark-shared \
+    && ! array_contains_value worker_args /artifacts:/opt/spark-driver:ro \
+    && array_contains_value driver_args /artifacts:/opt/spark-driver:ro \
+    && array_contains_value driver_args /shared:/opt/spark-shared \
+    && array_contains_value driver_args /events:/opt/spark-events
+}
+
+test_diagnostics_permissions_are_fixed_in_a_container() {
+  declare -F spark_diagnostics_permissions_container_args >/dev/null || return 1
+
+  local -a permissions_args=()
+  spark_diagnostics_permissions_container_args \
+    permissions_args official-spark-image /diagnostics-on-host
+
+  array_contains_sequence permissions_args run --rm \
+    --volume /diagnostics-on-host:/diagnostics \
+    --user 0:0 --entrypoint chmod official-spark-image -R a+rX /diagnostics
+}
+
+test_runner_uses_official_image_without_host_distribution() {
+  local runner="$CI_DIR/run.sh"
+  ! grep -Fq 'java -version 2>&1 | head -1' "$runner" \
+    && [ "$(grep -Fc 'retry_command 3 5 docker_command pull' "$runner")" -eq 2 ] \
+    && grep -Fq 'spark_diagnostics_permissions_container_args' "$runner" \
+    && ! grep -Eq 'SPARK_CACHE_DIR|SPARK_HOME_OVERRIDE|acquire_spark|sha512sum|spark-[^ ]+-bin-hadoop3\\.tgz' "$runner"
+}
+
+test_spark_readiness_uses_canonical_json_endpoint() {
+  grep -Fq 'http://127.0.0.1:${SPARK_MASTER_UI_PORT}/json/' "$CI_DIR/run.sh"
+}
+
+test_starrocks_uses_explicit_port_mappings() {
+  local runner="$CI_DIR/run.sh" mapping internal host default_port
+  ! grep -Fq -- '--network host' "$runner" || return 1
+  for mapping in \
+      STARROCKS_FE_HTTP_PORT,STARROCKS_FE_HTTP_HOST_PORT \
+      STARROCKS_FE_JDBC_PORT,STARROCKS_FE_JDBC_HOST_PORT \
+      STARROCKS_BE_HTTP_PORT,STARROCKS_BE_HTTP_HOST_PORT \
+      STARROCKS_BE_THRIFT_PORT,STARROCKS_BE_THRIFT_HOST_PORT \
+      STARROCKS_BE_BRPC_PORT,STARROCKS_BE_BRPC_HOST_PORT; do
+    IFS=',' read -r internal host <<< "$mapping"
+    grep -Fq -- "--publish \"\${$host}:\${$internal}\"" "$runner" || return 1
+  done
+  for mapping in \
+      STARROCKS_FE_HTTP_HOST_PORT,18030 \
+      STARROCKS_FE_JDBC_HOST_PORT,19030 \
+      STARROCKS_BE_HTTP_HOST_PORT,18040 \
+      STARROCKS_BE_THRIFT_HOST_PORT,19060 \
+      STARROCKS_BE_BRPC_HOST_PORT,18060; do
+    IFS=',' read -r host default_port <<< "$mapping"
+    grep -Fq "${host}=\"\${${host}:-$default_port}\"" "$runner" || return 1
+  done
+}
+
+test_starrocks_registers_bridge_address() {
+  local bootstrap="$CI_DIR/start-starrocks.sh" runner="$CI_DIR/run.sh"
+  [ -f "$bootstrap" ] || return 1
+  grep -Fq \
+    'starrocks/allin1-ubuntu:3.5.5@sha256:711dbcdec06a93858bf37ab6e197f36fa707e0488bd4f9c06fa1c666d9ef8149' \
+    "$runner" || return 1
+  grep -Fq 'hostname -i' "$bootstrap" || return 1
+  grep -Fq 'priority_networks = ${container_ip}/32' "$bootstrap" || return 1
+  grep -Fq 'MYHOST=${container_ip}' "$bootstrap" || return 1
+  grep -Fq -- '--entrypoint /bin/bash' "$runner" || return 1
+  grep -Fq 'start-starrocks.sh:/opt/starrocks-ci/start-starrocks.sh:ro' "$runner" || return 1
+}
+
+test_github_real_cluster_matrix() {
+  local workflow="$REPO_ROOT/.github/workflows/ci-pipeline.yml" tuple
+  grep -Fq 'fail-fast: false' "$workflow" || return 1
+  grep -Fq 'workflow_dispatch:' "$workflow" || return 1
+  grep -Fq 'actions/checkout@v7' "$workflow" || return 1
+  grep -Fq 'actions/setup-java@v5' "$workflow" || return 1
+  ! grep -Fq 'actions/cache@' "$workflow" || return 1
+  ! grep -Fq 'Cache Spark' "$workflow" || return 1
+  grep -Fq 'actions/upload-artifact@v7' "$workflow" || return 1
+  grep -Fq 'if: always()' "$workflow" || return 1
+  grep -Fq './ci/real-cluster/run.sh "${{ matrix.spark }}"' "$workflow" || return 1
+  grep -Eq '^[[:space:]]+docker info[[:space:]]*$' "$workflow" || return 1
+  ! grep -Fq 'docker info || true' "$workflow" || return 1
+
+  for tuple in \
+      '3.3|3.3.2|2.12|8' \
+      '3.4|3.4.0|2.12|8' \
+      '3.5|3.5.0|2.12|8' \
+      '4.0|4.0.0|2.13|17' \
+      '4.1|4.1.0|2.13|17'; do
+    IFS='|' read -r spark full scala java <<< "$tuple"
+    grep -A4 -F -- "- spark: '$spark'" "$workflow" \
+      | grep -Fq "full-version: '$full'" || return 1
+    grep -A4 -F -- "- spark: '$spark'" "$workflow" \
+      | grep -Fq "scala: '$scala'" || return 1
+    grep -A4 -F -- "- spark: '$spark'" "$workflow" \
+      | grep -Fq "java: '$java'" || return 1
+  done
+}
+
+assert_success "exact Spark, Scala, build JDK, and runtime JDK mappings" test_version_mappings
+assert_success "Apache official Spark images are pinned by digest" test_official_spark_images_are_pinned
+assert_success "Java version output is parsed without a truncating pipe" test_java_output_is_parsed_without_a_pipe
+assert_success "Spark version output is parsed" test_spark_version_output_is_parsed
+assert_success "transient commands are retried" test_retry_command_retries_transient_failures
+assert_success "unsupported Spark version is rejected" test_unsupported_version_rejected
+assert_success "primary connector JAR is selected" test_find_connector_jar
+assert_success "missing connector JAR is rejected" test_missing_connector_jar_rejected
+assert_success "multiple connector JARs are rejected" test_multiple_connector_jars_rejected
+assert_success "connector packages use one validation contract across Spark versions" test_connector_jars_for_all_versions_accepted
+assert_success "smoke JAR requires compiled smoke classes" test_smoke_jar_requires_compiled_classes
+assert_success "smoke JAR contains only smoke application classes" test_smoke_jar_contains_only_smoke_classes
+assert_success "MySQL connector JAR is resolved from Maven cache" test_find_mysql_jar
+assert_success "missing MySQL connector JAR is rejected" test_missing_mysql_jar_rejected
+assert_success "Spark worker readiness parses an ALIVE worker" test_spark_worker_readiness_parser
+assert_success "StarRocks backend readiness parses the Alive column" test_starrocks_backend_readiness_parser
+assert_success "FE HTTP readiness accepts an authenticated endpoint response" test_fe_http_readiness_accepts_authentication_response
+assert_success "cluster runner rejects missing and unsupported versions" test_cluster_runner_rejects_bad_arguments
+assert_success "Spark master, worker, and driver use one container network" test_spark_roles_use_one_container_network
+assert_success "worker receives shared data without driver artifact mounts" test_worker_has_shared_data_but_not_driver_artifacts
+assert_success "container-created diagnostics are made readable" test_diagnostics_permissions_are_fixed_in_a_container
+assert_success "runner uses the official image without a host Spark distribution" test_runner_uses_official_image_without_host_distribution
+assert_success "distributed evidence comes from the worker container" test_executor_evidence_requires_worker_container
+assert_success "Spark readiness uses the canonical JSON endpoint" test_spark_readiness_uses_canonical_json_endpoint
+assert_success "StarRocks exposes FE and BE ports without host networking" test_starrocks_uses_explicit_port_mappings
+assert_success "StarRocks advertises its reachable bridge address" test_starrocks_registers_bridge_address
+assert_success "GitHub workflow runs the five-version real-cluster matrix" test_github_real_cluster_matrix
+
+printf '\n%d passed, %d failed\n' "$passed" "$failed"
+[ "$failed" -eq 0 ]

--- a/pom.xml
+++ b/pom.xml
@@ -70,12 +70,14 @@
         <netty.version>4.1.87.Final</netty.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.15</httpcore.version>
+        <httpclient.scope>provided</httpclient.scope>
         <fastjson.version>1.2.83</fastjson.version>
         <java.source.version>8</java.source.version>
         <java.target.version>8</java.target.version>
         <scala-maven-plugin.version>3.2.1</scala-maven-plugin.version>
         <mockito-scala.version>1.6.2</mockito-scala.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
+        <maven-shade-plugin.version>3.2.1</maven-shade-plugin.version>
         <surefire.argLine></surefire.argLine>
     </properties>
 
@@ -288,12 +290,14 @@
                 <netty.version>4.2.7.Final</netty.version>
                 <httpclient.version>4.5.14</httpclient.version>
                 <httpcore.version>4.4.16</httpcore.version>
+                <httpclient.scope>compile</httpclient.scope>
                 <java.source.version>17</java.source.version>
                 <java.target.version>17</java.target.version>
                 <scala-maven-plugin.version>4.9.5</scala-maven-plugin.version>
                 <mockito-scala.version>1.17.37</mockito-scala.version>
                 <commons-lang3.version>3.19.0</commons-lang3.version>
                 <arrow.version>18.3.0</arrow.version>
+                <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
                 <surefire.argLine>--add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED</surefire.argLine>
             </properties>
 
@@ -305,6 +309,23 @@
                     <scope>provided</scope>
                 </dependency>
             </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.http</pattern>
+                                    <shadedPattern>com.starrocks.connector.spark.shaded.org.apache.http</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
 
         </profile>
 
@@ -400,14 +421,24 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>${httpclient.version}</version>
-            <scope>provided</scope>
+            <scope>${httpclient.scope}</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
             <version>${httpcore.version}</version>
-            <scope>provided</scope>
+            <scope>${httpclient.scope}</scope>
         </dependency>
 
         <dependency>
@@ -622,7 +653,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${maven-shade-plugin.version}</version>
                 <configuration>
                     <artifactSet>
                         <excludes>

--- a/src/main/java/com/starrocks/connector/spark/util/JsonUtils.java
+++ b/src/main/java/com/starrocks/connector/spark/util/JsonUtils.java
@@ -26,9 +26,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-
 public class JsonUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(JsonUtils.class);
@@ -59,16 +56,16 @@ public class JsonUtils {
             return;
         }
         try {
-            Field constraintsField = JsonFactory.class.getDeclaredField("_streamReadConstraints");
-            constraintsField.setAccessible(true);
-            Object constraints = constraintsField.get(jsonFactory);
-
-            Field maxStringLenField = constraints.getClass().getDeclaredField("_maxStringLen");
-            maxStringLenField.setAccessible(true);
-            Field modifiersField = Field.class.getDeclaredField("modifiers");
-            modifiersField.setAccessible(true);
-            modifiersField.setInt(maxStringLenField, maxStringLenField.getModifiers() & ~Modifier.FINAL);
-            maxStringLenField.setInt(constraints, maxStringLen);
+            Class<?> constraintsClass =
+                    Class.forName("com.fasterxml.jackson.core.StreamReadConstraints");
+            Object constraints =
+                    JsonFactory.class.getMethod("streamReadConstraints").invoke(jsonFactory);
+            Object builder = constraintsClass.getMethod("rebuild").invoke(constraints);
+            builder.getClass().getMethod("maxStringLength", int.class).invoke(builder, maxStringLen);
+            Object updatedConstraints = builder.getClass().getMethod("build").invoke(builder);
+            JsonFactory.class
+                    .getMethod("setStreamReadConstraints", constraintsClass)
+                    .invoke(jsonFactory, updatedConstraints);
         } catch (Exception e) {
             LOG.warn("Failed to set max string length {}", maxStringLen, e);
         }

--- a/src/test/java/com/starrocks/connector/spark/util/JsonUtilsTest.java
+++ b/src/test/java/com/starrocks/connector/spark/util/JsonUtilsTest.java
@@ -1,0 +1,46 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.connector.spark.util;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class JsonUtilsTest {
+
+    private static final int EXPECTED_MAX_STRING_LENGTH = 1024 * 1024 * 1024;
+
+    @Test
+    public void testMaxStringLengthWhenSupported() throws Exception {
+        Class<?> constraintsClass;
+        try {
+            constraintsClass = Class.forName("com.fasterxml.jackson.core.StreamReadConstraints");
+        } catch (ClassNotFoundException e) {
+            return;
+        }
+
+        JsonFactory jsonFactory = JsonUtils.createObjectMapper().getFactory();
+        Object constraints = JsonFactory.class.getMethod("streamReadConstraints").invoke(jsonFactory);
+        int actualMaxStringLength =
+                (int) constraintsClass.getMethod("getMaxStringLength").invoke(constraints);
+
+        Assertions.assertEquals(EXPECTED_MAX_STRING_LENGTH, actualMaxStringLength);
+    }
+}

--- a/src/test/scala/com/starrocks/connector/spark/ci/ConnectorDocsSmoke.scala
+++ b/src/test/scala/com/starrocks/connector/spark/ci/ConnectorDocsSmoke.scala
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.starrocks.connector.spark.ci
+
+import java.net.InetAddress
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+import java.sql.{Connection, DriverManager}
+
+import scala.collection.mutable.ArrayBuffer
+
+import com.starrocks.connector.spark._
+import org.apache.spark.SparkEnv
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.streaming.Trigger
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+
+/**
+ * Runs the core examples from connector-write.md and connector-read.md against
+ * a packaged connector JAR on a real Spark standalone worker.
+ */
+object ConnectorDocsSmoke {
+
+  private case class Config(
+      database: String,
+      sharedWorkDirectory: String,
+      feHttp: String,
+      feJdbc: String,
+      expectedConnectorName: String) {
+    val user = "root"
+    val password = ""
+  }
+
+  private def requireCheck(condition: Boolean, message: String): Unit = {
+    if (!condition) {
+      throw new IllegalStateException(message)
+    }
+  }
+
+  private def withJdbc[T](config: Config)(body: Connection => T): T = {
+    Class.forName("com.mysql.cj.jdbc.Driver")
+    val separator = if (config.feJdbc.contains("?")) "&" else "?"
+    val connection = DriverManager.getConnection(
+      config.feJdbc + separator + "useSSL=false&allowPublicKeyRetrieval=true",
+      config.user,
+      config.password)
+    try body(connection) finally connection.close()
+  }
+
+  private def execute(connection: Connection, sql: String): Unit = {
+    val statement = connection.createStatement()
+    try statement.execute(sql) finally statement.close()
+  }
+
+  private def prepareStarRocks(config: Config): Unit = withJdbc(config) { connection =>
+    execute(connection, s"DROP DATABASE IF EXISTS `${config.database}`")
+    execute(connection, s"CREATE DATABASE `${config.database}`")
+
+    val tableDdl =
+      """(
+        |  `id` INT NOT NULL,
+        |  `name` VARCHAR(65533) NULL DEFAULT "",
+        |  `score` INT NOT NULL DEFAULT "0"
+        |)
+        |ENGINE=OLAP
+        |PRIMARY KEY(`id`)
+        |DISTRIBUTED BY HASH(`id`) BUCKETS 1
+        |PROPERTIES ("replication_num" = "1")
+        |""".stripMargin
+
+    execute(connection, s"CREATE TABLE `${config.database}`.`score_board_write` $tableDdl")
+    execute(connection, s"CREATE TABLE `${config.database}`.`score_board_read` $tableDdl")
+    execute(connection,
+      s"""INSERT INTO `${config.database}`.`score_board_read` VALUES
+         |(1, 'Bob', 21), (2, 'Stan', 21), (3, 'Sam', 22),
+         |(4, 'Tony', 22), (5, 'Alice', 22), (6, 'Lucy', 23),
+         |(7, 'Polly', 23), (8, 'Tom', 23), (9, 'Rose', 24),
+         |(10, 'Jerry', 24), (11, 'Jason', 24), (12, 'Lily', 25),
+         |(13, 'Stephen', 25), (14, 'David', 25), (15, 'Eddie', 26),
+         |(16, 'Kate', 27), (17, 'Cathy', 27), (18, 'Judy', 27),
+         |(19, 'Julia', 28), (20, 'Robert', 28), (21, 'Jack', 29)
+         |""".stripMargin)
+  }
+
+  private def options(config: Config, table: String): Map[String, String] = Map(
+    "starrocks.fe.http.url" -> config.feHttp,
+    "starrocks.fe.jdbc.url" -> config.feJdbc,
+    "starrocks.table.identifier" -> s"${config.database}.$table",
+    "starrocks.user" -> config.user,
+    "starrocks.password" -> config.password)
+
+  private def sqlOptions(config: Config, table: String): String =
+    s"""(
+       |  "starrocks.fe.http.url"="${config.feHttp}",
+       |  "starrocks.fe.jdbc.url"="${config.feJdbc}",
+       |  "starrocks.table.identifier"="${config.database}.$table",
+       |  "starrocks.user"="${config.user}",
+       |  "starrocks.password"="${config.password}"
+       |)""".stripMargin
+
+  private def starRocksDataFrame(
+      spark: SparkSession,
+      config: Config,
+      table: String): DataFrame = {
+    spark.read.format("starrocks").options(options(config, table)).load()
+  }
+
+  private def jdbcRows(config: Config, table: String): Seq[(Int, String, Int)] =
+    withJdbc(config) { connection =>
+      val statement = connection.createStatement()
+      val result = statement.executeQuery(
+        s"SELECT id, name, score FROM `${config.database}`.`$table` ORDER BY id")
+      val rows = ArrayBuffer.empty[(Int, String, Int)]
+      try {
+        while (result.next()) {
+          rows += ((result.getInt(1), result.getString(2), result.getInt(3)))
+        }
+      } finally {
+        result.close()
+        statement.close()
+      }
+      rows.toSeq
+    }
+
+  private def awaitJdbcIds(
+      config: Config,
+      table: String,
+      expectedIds: Seq[Int],
+      timeoutMs: Long = 120000L): Unit = {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    var actualIds = Seq.empty[Int]
+    while (System.currentTimeMillis() < deadline) {
+      actualIds = jdbcRows(config, table).map(_._1)
+      if (actualIds == expectedIds) {
+        return
+      }
+      Thread.sleep(1000L)
+    }
+    throw new IllegalStateException(
+      s"Timed out waiting for $table IDs ${expectedIds.mkString(",")}; " +
+        s"last result was ${actualIds.mkString(",")}")
+  }
+
+  def main(args: Array[String]): Unit = {
+    requireCheck(
+      args.length == 5,
+      "Expected arguments: <database> <shared-work-directory> <fe-http> <fe-jdbc> " +
+        "<expected-connector-name>")
+    val config = Config(args(0), args(1), args(2), args(3), args(4))
+    val workDirectory = Paths.get(
+      config.sharedWorkDirectory,
+      config.database + "-" + System.currentTimeMillis())
+    val inputDirectory = workDirectory.resolve("csv-data")
+    val checkpointDirectory = workDirectory.resolve("checkpoint")
+    Files.createDirectories(inputDirectory)
+
+    prepareStarRocks(config)
+
+    val spark = SparkSession.builder()
+      .appName("StarRocks connector docs smoke " + config.database)
+      .getOrCreate()
+    try {
+      spark.sparkContext.setLogLevel("WARN")
+      import spark.implicits._
+
+      val connectorLocation = classOf[com.starrocks.connector.spark.sql.StarRocksDataSourceProvider]
+        .getProtectionDomain.getCodeSource.getLocation.toString
+      println(
+        s"VALIDATION_ENV spark=${spark.version} scala=${scala.util.Properties.versionNumberString} " +
+          s"master=${spark.sparkContext.master} connector=$connectorLocation")
+      requireCheck(
+        spark.sparkContext.master.startsWith("spark://"),
+        "The smoke test must run on a standalone Spark cluster")
+      requireCheck(
+        connectorLocation.contains(config.expectedConnectorName),
+        s"Driver loaded connector from unexpected location: $connectorLocation")
+
+      val executorEvidence = spark.sparkContext.parallelize(1 to 40, 4).mapPartitions { values =>
+        val executorId = SparkEnv.get.executorId
+        val host = InetAddress.getLocalHost.getHostName
+        val location = Class.forName("com.starrocks.connector.spark.sql.StarRocksDataSourceProvider")
+          .getProtectionDomain.getCodeSource.getLocation.toString
+        Iterator(s"$executorId@$host:${values.sum}:$location")
+      }.collect()
+      requireCheck(
+        executorEvidence.exists(value => !value.startsWith("driver@")),
+        "No standalone executor executed the distributed probe")
+      requireCheck(
+        executorEvidence.forall(_.contains(config.expectedConnectorName)),
+        "An executor loaded the connector from an unexpected location: " +
+          executorEvidence.mkString(","))
+      println("CHECK distributed_execution PASS " + executorEvidence.mkString(","))
+
+      val batch = Seq((1, "starrocks", 100), (2, "spark", 100)).toDF("id", "name", "score")
+      batch.repartition(2).write.format("starrocks")
+        .options(options(config, "score_board_write"))
+        .mode("append")
+        .save()
+      awaitJdbcIds(config, "score_board_write", Seq(1, 2))
+      println("CHECK dataframe_batch_write PASS ids=1,2")
+
+      val streamSchema = StructType(Seq(
+        StructField("id", IntegerType, nullable = false),
+        StructField("name", StringType, nullable = true),
+        StructField("score", IntegerType, nullable = false)))
+      val streamData = spark.readStream
+        .option("sep", ",")
+        .schema(streamSchema)
+        .format("csv")
+        .load(inputDirectory.toString)
+      Files.write(
+        inputDirectory.resolve("test.csv"),
+        "3,starrocks,100\n4,spark,100\n".getBytes(StandardCharsets.UTF_8))
+      val streamQuery = streamData.writeStream.format("starrocks")
+        .options(options(config, "score_board_write"))
+        .option("checkpointLocation", checkpointDirectory.toString)
+        .outputMode("append")
+        .trigger(Trigger.Once())
+        .start()
+      requireCheck(
+        streamQuery.awaitTermination(120000L),
+        "Structured Streaming write did not terminate within 120 seconds")
+      awaitJdbcIds(config, "score_board_write", Seq(1, 2, 3, 4))
+      println("CHECK structured_streaming_write PASS ids=3,4")
+
+      spark.sql("DROP TABLE IF EXISTS score_board_sql")
+      spark.sql(
+        s"CREATE TABLE score_board_sql USING starrocks " +
+          s"OPTIONS ${sqlOptions(config, "score_board_write")}")
+      spark.sql("INSERT INTO score_board_sql VALUES (5, 'starrocks', 100), (6, 'spark', 100)")
+      awaitJdbcIds(config, "score_board_write", Seq(1, 2, 3, 4, 5, 6))
+      println("CHECK spark_sql_write PASS ids=5,6")
+
+      spark.sql(
+        s"CREATE OR REPLACE TEMPORARY VIEW spark_starrocks USING starrocks " +
+          s"OPTIONS ${sqlOptions(config, "score_board_read")}")
+      val sqlReadRows = spark.sql(
+        "SELECT id, name, score FROM spark_starrocks ORDER BY id").collect()
+      requireCheck(
+        sqlReadRows.length == 21 && sqlReadRows.head.getInt(0) == 1 &&
+          sqlReadRows.last.getInt(0) == 21,
+        "Spark SQL read did not return the expected 21 rows")
+      println("CHECK spark_sql_read PASS rows=21 first=Bob last=Jack")
+
+      val dataFrameRows = starRocksDataFrame(spark, config, "score_board_read")
+        .orderBy("id").limit(10).collect()
+      requireCheck(
+        dataFrameRows.length == 10 && dataFrameRows.head.getString(1) == "Bob" &&
+          dataFrameRows.last.getString(1) == "Jerry",
+        "Spark DataFrame read did not return the expected first 10 rows")
+      println("CHECK dataframe_read PASS rows=10 first=Bob tenth=Jerry")
+
+      val starrocksSparkRDD = spark.sparkContext.starrocksRDD(
+        tableIdentifier = Some(s"${config.database}.score_board_read"),
+        cfg = Some(Map(
+          "starrocks.fenodes" -> config.feHttp,
+          "starrocks.request.auth.user" -> config.user,
+          "starrocks.request.auth.password" -> config.password)))
+      val rddRows = starrocksSparkRDD.collect()
+      requireCheck(rddRows.length == 21, "Spark RDD read did not return the expected 21 rows")
+      println("CHECK rdd_read PASS rows=21 sample=" + rddRows.head)
+
+      val writtenRows = starRocksDataFrame(spark, config, "score_board_write")
+        .orderBy("id").collect()
+      requireCheck(
+        writtenRows.map(_.getInt(0)).toSeq == Seq(1, 2, 3, 4, 5, 6),
+        "Connector readback did not return all six written rows")
+      requireCheck(
+        jdbcRows(config, "score_board_write").map(_._1) == Seq(1, 2, 3, 4, 5, 6),
+        "JDBC readback did not return all six written rows")
+      println("CHECK connector_and_jdbc_readback PASS ids=1,2,3,4,5,6")
+
+      println(s"VALIDATION_RESULT PASS spark=${spark.version} database=${config.database}")
+    } finally {
+      spark.stop()
+    }
+  }
+}


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [x] Tool

## Which issues of this PR fixes ：

N/A

## Problem Summary(Required) ：

Spark 4.1 no longer ships Apache HttpClient 4, while the connector and bundled stream-load SDK still reference it. The 1.1.4-RC0 Spark 4.1 artifact therefore fails at runtime with `NoClassDefFoundError: org/apache/http/auth/AuthenticationException` even though Maven tests pass through their dependency classpath.

Jackson 2.15+ also introduced a configurable maximum string length. The connector tried to raise it by mutating Jackson private fields and `java.lang.reflect.Field.modifiers`; JDK 17 no longer exposes that field, so Spark 4.0/4.1 logged `NoSuchFieldException: modifiers` and silently retained Jackson's default 20,000,000-character limit.

This PR:

- packages HttpClient/HttpCore only for the Spark 4.1 artifact and relocates them under the connector namespace to avoid dependency conflicts;
- configures Jackson 2.15+ through its public `StreamReadConstraints` builder API while retaining binary compatibility with the older Jackson versions used by Spark 3.3/3.4;
- adds a cross-version unit test that verifies the effective 1 GiB limit whenever the Jackson API is available;
- adds a five-way GitHub Actions matrix for Spark 3.3.2, 3.4.0, 3.5.0, 4.0.0, and 4.1.0 with their matching Scala/build-JDK versions;
- uses digest-pinned Apache official Spark images directly, and separately validates the Spark version and image runtime JDK before cluster startup;
- starts Spark master, worker, and driver from the image's own `/opt/spark` installation, with no host Spark distribution download, mount, or GitHub cache;
- runs Spark and StarRocks FE/BE on one isolated Docker bridge network for every matrix entry;
- mounts connector, MySQL, and smoke artifacts only into the driver container so Spark must distribute the application dependencies to the worker;
- runs eight write/read scenarios derived from `connector-write.md` and `connector-read.md`, and requires distributed execution evidence to come from the `spark-worker` container;
- retries transient image pulls and uploads readable container/cluster diagnostics unconditionally;
- removes class-count checks from the release verifier, leaving runtime packaging validation to the real-cluster connector scenarios;
- upgrades the workflow to checkout v7, setup-java v5, and upload-artifact v7.

The CI harness contains no dependency-specific checks. Runtime dependency and packaging regressions are detected through the same end-to-end connector behavior on all five Spark versions.

Verification:

- CI harness contract tests: 27 passed;
- release-skill tests: 30 passed;
- shell syntax, ShellCheck, and `git diff --check`: passed;
- Spark 4.1 Maven tests: 57 run, 0 failures, 0 errors, 1 skipped;
- local `JsonUtilsTest` passed on Spark 3.3/JDK 8, Spark 3.5/JDK 17, and Spark 4.1/JDK 17 profiles;
- final Spark 4.1 shaded package build passed.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
