### PR TITLE
[Doc][CI] Add Spark connector 1.1.4 requirements

### DIFF
--- a/ci/real-cluster/spark-containers.sh
+++ b/ci/real-cluster/spark-containers.sh
@@ -43,8 +43,8 @@ spark_master_container_args() {
   output+=(
     --publish "127.0.0.1:${web_ui_host_port}:8080"
     --detach
-    --entrypoint /opt/spark/bin/spark-class
     "$image"
+    /opt/spark/bin/spark-class
     org.apache.spark.deploy.master.Master
     --host spark-master
     --port 7077
@@ -64,8 +64,8 @@ spark_worker_container_args() {
     --volume "$worker_work:/opt/spark-work"
     --env SPARK_WORKER_DIR=/opt/spark-work
     --detach
-    --entrypoint /opt/spark/bin/spark-class
     "$image"
+    /opt/spark/bin/spark-class
     org.apache.spark.deploy.worker.Worker
     --host spark-worker
     --port 7078
@@ -87,8 +87,8 @@ spark_driver_container_args() {
     --volume "$artifacts:/opt/spark-driver:ro"
     --volume "$shared_work:/opt/spark-shared"
     --volume "$events:/opt/spark-events"
-    --entrypoint /opt/spark/bin/spark-submit
     "$image"
+    /opt/spark/bin/spark-submit
   )
 }
 

--- a/ci/real-cluster/tests/run_tests.sh
+++ b/ci/real-cluster/tests/run_tests.sh
@@ -333,19 +333,36 @@ test_spark_roles_use_one_container_network() {
   array_contains_sequence master_args --network cluster-net \
     && array_contains_sequence master_args --hostname spark-master \
     && array_contains_sequence master_args --publish 127.0.0.1:28080:8080 \
-    && array_contains_sequence master_args --entrypoint /opt/spark/bin/spark-class \
-      official-spark-image org.apache.spark.deploy.master.Master \
     && array_contains_sequence worker_args --network cluster-net \
     && array_contains_sequence worker_args --hostname spark-worker \
-    && array_contains_sequence worker_args --entrypoint /opt/spark/bin/spark-class \
-      official-spark-image org.apache.spark.deploy.worker.Worker \
     && array_contains_sequence driver_args --network cluster-net \
     && array_contains_sequence driver_args --hostname spark-driver \
-    && array_contains_sequence driver_args --entrypoint /opt/spark/bin/spark-submit \
-      official-spark-image \
     && ! array_contains_mount_target master_args /opt/spark \
     && ! array_contains_mount_target worker_args /opt/spark \
     && ! array_contains_mount_target driver_args /opt/spark
+}
+
+test_spark_roles_use_the_official_image_entrypoint() {
+  declare -F spark_master_container_args >/dev/null || return 1
+  declare -F spark_worker_container_args >/dev/null || return 1
+  declare -F spark_driver_container_args >/dev/null || return 1
+
+  local -a master_args=() worker_args=() driver_args=()
+  spark_master_container_args master_args master-id cluster-net official-spark-image 28080
+  spark_worker_container_args \
+    worker_args worker-id cluster-net official-spark-image /shared /worker
+  spark_driver_container_args \
+    driver_args driver-id cluster-net official-spark-image /artifacts /shared /events
+
+  ! array_contains_value master_args --entrypoint \
+    && ! array_contains_value worker_args --entrypoint \
+    && ! array_contains_value driver_args --entrypoint \
+    && array_contains_sequence master_args official-spark-image \
+      /opt/spark/bin/spark-class org.apache.spark.deploy.master.Master \
+    && array_contains_sequence worker_args official-spark-image \
+      /opt/spark/bin/spark-class org.apache.spark.deploy.worker.Worker \
+    && array_contains_sequence driver_args official-spark-image \
+      /opt/spark/bin/spark-submit
 }
 
 test_executor_evidence_requires_worker_container() {
@@ -493,6 +510,7 @@ assert_success "StarRocks backend readiness parses the Alive column" test_starro
 assert_success "FE HTTP readiness accepts an authenticated endpoint response" test_fe_http_readiness_accepts_authentication_response
 assert_success "cluster runner rejects missing and unsupported versions" test_cluster_runner_rejects_bad_arguments
 assert_success "Spark master, worker, and driver use one container network" test_spark_roles_use_one_container_network
+assert_success "Spark roles use the official image entrypoint" test_spark_roles_use_the_official_image_entrypoint
 assert_success "worker receives shared data without driver artifact mounts" test_worker_has_shared_data_but_not_driver_artifacts
 assert_success "container-created diagnostics are made readable" test_diagnostics_permissions_are_fixed_in_a_container
 assert_success "runner uses the official image without a host Spark distribution" test_runner_uses_official_image_without_host_distribution

--- a/docs/connector-read.md
+++ b/docs/connector-read.md
@@ -21,6 +21,8 @@ You can also map the StarRocks table to a Spark DataFrame or a Spark RDD, and th
 
 | Spark connector | Spark         | StarRocks       | Java | Scala |
 |-----------------| ------------- | --------------- | ---- | ----- |
+| 1.1.4           | 3.3, 3.4, 3.5 | 2.5 and later   | 8    | 2.12  |
+|                 | 4.0, 4.1      | 2.5 and later   | 17   | 2.13  |
 | 1.1.3           | 3.2, 3.3, 3.4, 3.5 | 2.5 and later   | 8    | 2.12  |
 | 1.1.2           | 3.2, 3.3, 3.4, 3.5 | 2.5 and later   | 8    | 2.12  |
 | 1.1.1           | 3.2, 3.3, 3.4 | 2.5 and later   | 8    | 2.12  |

--- a/docs/connector-write.md
+++ b/docs/connector-write.md
@@ -10,6 +10,8 @@ StarRocks provides a self-developed connector named StarRocks Connector for Apac
 
 | Spark connector | Spark            | StarRocks     | Java | Scala |
 |-----------------| ---------------- | ------------- | ---- | ----- |
+| 1.1.4           | 3.3, 3.4, 3.5    | 2.5 and later | 8    | 2.12  |
+|                 | 4.0, 4.1         | 2.5 and later | 17   | 2.13  |
 | 1.1.3           | 3.2, 3.3, 3.4, 3.5 | 2.5 and later   | 8    | 2.12  |
 | 1.1.2           | 3.2, 3.3, 3.4, 3.5 | 2.5 and later   | 8    | 2.12  |
 | 1.1.1           | 3.2, 3.3, or 3.4 | 2.5 and later | 8    | 2.12  |


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [x] Tool

## Which issues of this PR fixes ：

N/A

## Problem Summary(Required) ：

Add the upcoming Spark connector 1.1.4 compatibility information to both connector version-requirements tables. The Spark connector column contains `1.1.4` only once, while the remaining requirements are grouped by Spark major version:

- Spark 3.3, 3.4, and 3.5: Java 8 / Scala 2.12
- Spark 4.0 and 4.1: Java 17 / Scala 2.13
- StarRocks 2.5 and later

The real-cluster matrix also exposed a Spark 3.3 official-image startup failure. The image runs as UID 185, and its `/opt/entrypoint.sh` creates the missing passwd entry before launching Spark. The CI helper bypassed that setup by replacing the image entrypoint with `spark-class` or `spark-submit`, causing Hadoop UGI to fail while resolving the current user.

Preserve the official image entrypoint for the Spark master, worker, and driver, and pass the Spark executable as the container command. This is common behavior for every supported Spark image and contains no version-specific workaround.

Verification:

- exact Spark 3.3.2 official image: containerized master, worker, and driver completed all 8 connector write/read smoke checks
- real-cluster argument tests: 28 passed, including official-entrypoint coverage for all Spark roles
- spark-connector-release tests: 30 passed
- release documentation gate recognizes the exact 1.1.4 row in both documents
- Bash syntax and `git diff --check` passed
- hosted CI run 31123061833: Spark 3.4, 3.5, 4.0, and 4.1 passed; Spark 3.3 supplied the diagnostic evidence reproduced and fixed above

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
- [x] I have added documentation for my new feature or new function
